### PR TITLE
use fast forward when squashing

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -187,7 +187,7 @@ func done() {
 
 		git("checkout", baseBranch)
 		git("merge", remoteName+"/"+baseBranch, "--ff-only")
-		git("merge", "--squash", wipBranch)
+		git("merge", "--squash", "--ff", wipBranch)
 
 		git("branch", "-D", wipBranch)
 		git("push", remoteName, "--delete", wipBranch)


### PR DESCRIPTION
Squashing is not allowed unless fast forward is used as merging strategy. FF is the default, but could be overridden in `.gitconfig`, and hence it could be nice to correct this when running the automated command.

How to disable fast forward in `.gitconfig`:
```gitconfig
[merge]
        ff = false
```

If you have disabled FF you will get the following error when running `mob done`:

```
...

[git merge --squash mob-session]
fatal: You cannot combine --squash with --no-ff.

 ⚡ [git merge --squash mob-session]
 ⚡ exit status 128
```