### PR TITLE
Allow --no-verify when committing and pushing WIP commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ export MOB_REMOTE_NAME=origin
 export MOB_WIP_COMMIT_MESSAGE="mob next [ci-skip]"
 export MOB_NEXT_STAY=false # set to true to stay in the MOB_WIP_BRANCH after 'mob next' instead of checking out MOB_BASE_BRANCH
 export MOB_DEBUG=false
+export MOB_WIP_NO_VERIFY=false # set to true to make commit and push on WIP commits use the --no-verify flag
 ```
 
 The easiest way to enable them for a single call is as follows:

--- a/mob.go
+++ b/mob.go
@@ -16,6 +16,7 @@ var remoteName = "origin"                   // override with MOB_REMOTE_NAME env
 var wipCommitMessage = "mob next [ci-skip]" // override with MOB_WIP_COMMIT_MESSAGE environment variable
 var mobNextStay = false                     // override with MOB_NEXT_STAY environment variable
 var debug = false                           // override with MOB_DEBUG environment variable
+var wipPushFlags = ""               	    // override with MOB_WIP_PUSH_FLAGS environment variable
 
 func parseEnvironmentVariables() []string {
 	userBaseBranch, userBaseBranchSet := os.LookupEnv("MOB_BASE_BRANCH")
@@ -37,6 +38,11 @@ func parseEnvironmentVariables() []string {
 	if userWipCommitMessageSet {
 		wipCommitMessage = userWipCommitMessage
 		say("overriding MOB_WIP_COMMIT_MESSAGE=" + wipCommitMessage)
+	}
+	userWipPushFlags, userWipPushFlagsSet := os.LookupEnv("MOB_WIP_PUSH_FLAGS")
+	if userWipPushFlagsSet {
+		wipPushFlags = userWipPushFlags
+		say("overriding MOB_WIP_PUSH_FLAGS=" + wipPushFlags)
 	}
 	_, userMobDebugSet := os.LookupEnv("MOB_DEBUG")
 	if userMobDebugSet {
@@ -186,7 +192,7 @@ func next() {
 		git("add", "--all")
 		git("commit", "--message", "\""+wipCommitMessage+"\"")
 		changes := getChangesOfLastCommit()
-		git("push", remoteName, wipBranch)
+		git("push", wipPushFlags, remoteName, wipBranch)
 		say(changes)
 	}
 	showNext()

--- a/mob.go
+++ b/mob.go
@@ -16,7 +16,8 @@ var remoteName = "origin"                   // override with MOB_REMOTE_NAME env
 var wipCommitMessage = "mob next [ci-skip]" // override with MOB_WIP_COMMIT_MESSAGE environment variable
 var mobNextStay = false                     // override with MOB_NEXT_STAY environment variable
 var debug = false                           // override with MOB_DEBUG environment variable
-var wipPushFlags = ""               	    // override with MOB_WIP_PUSH_FLAGS environment variable
+var wipNoVerify = false               	    // override with MOB_WIP_NO_VERIFY environment variable
+var wipGitFlags = ""
 
 func parseEnvironmentVariables() []string {
 	userBaseBranch, userBaseBranchSet := os.LookupEnv("MOB_BASE_BRANCH")
@@ -39,10 +40,11 @@ func parseEnvironmentVariables() []string {
 		wipCommitMessage = userWipCommitMessage
 		say("overriding MOB_WIP_COMMIT_MESSAGE=" + wipCommitMessage)
 	}
-	userWipPushFlags, userWipPushFlagsSet := os.LookupEnv("MOB_WIP_PUSH_FLAGS")
-	if userWipPushFlagsSet {
-		wipPushFlags = userWipPushFlags
-		say("overriding MOB_WIP_PUSH_FLAGS=" + wipPushFlags)
+	_, userWipNoVerifySet := os.LookupEnv("MOB_WIP_NO_VERIFY")
+	if userWipNoVerifySet {
+		wipNoVerify = true
+		wipGitFlags = "--no-verify"
+		say("overriding MOB_WIP_NO_VERIFY=" + strconv.FormatBool(wipNoVerify))
 	}
 	_, userMobDebugSet := os.LookupEnv("MOB_DEBUG")
 	if userMobDebugSet {
@@ -190,9 +192,9 @@ func next() {
 		sayInfo("nothing was done, so nothing to commit")
 	} else {
 		git("add", "--all")
-		git("commit", "--message", "\""+wipCommitMessage+"\"")
+		git("commit", wipGitFlags, "--message", "\""+wipCommitMessage+"\"")
 		changes := getChangesOfLastCommit()
-		git("push", wipPushFlags, remoteName, wipBranch)
+		git("push", wipGitFlags, remoteName, wipBranch)
 		say(changes)
 	}
 	showNext()


### PR DESCRIPTION
We have a few git hooks running when committing and pushing (lint/test etc), which caused this to fail when doing `mob next`.

This change allows for the -no-verify flag to be set on git commands during `mob next` so it skips the hooks and doesn't slow down or interrupt the handover.