### PR TITLE
Use the currently checked-out branch as the baseBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Swift handover for remote mobs using git.
 `mob` is a CLI tool written in GO.
-It keeps your master branch clean and creates WIP commits on `mob-session` branch.
+It keeps your working branch clean and creates WIP commits on `mob-session` branch.
 
 ## How to use it?
 
@@ -75,7 +75,6 @@ You can set several environment variables that will be picked up by `mob`:
 ```bash
 # override default values if necessary
 export MOB_WIP_BRANCH=mob-session
-export MOB_BASE_BRANCH=master
 export MOB_REMOTE_NAME=origin
 export MOB_WIP_COMMIT_MESSAGE="mob next [ci-skip]"
 export MOB_NEXT_STAY=false # set to true to stay in the MOB_WIP_BRANCH after 'mob next' instead of checking out MOB_BASE_BRANCH

--- a/mob.go
+++ b/mob.go
@@ -11,18 +11,13 @@ import (
 )
 
 var wipBranch = "mob-session"               // override with MOB_WIP_BRANCH environment variable
-var baseBranch = "master"                   // override with MOB_BASE_BRANCH environment variable
+var baseBranch = ""            				// will be set on start
 var remoteName = "origin"                   // override with MOB_REMOTE_NAME environment variable
 var wipCommitMessage = "mob next [ci-skip]" // override with MOB_WIP_COMMIT_MESSAGE environment variable
 var mobNextStay = false                     // override with MOB_NEXT_STAY environment variable
 var debug = false                           // override with MOB_DEBUG environment variable
 
 func parseEnvironmentVariables() []string {
-	userBaseBranch, userBaseBranchSet := os.LookupEnv("MOB_BASE_BRANCH")
-	if userBaseBranchSet {
-		baseBranch = userBaseBranch
-		say("overriding MOB_BASE_BRANCH=" + baseBranch)
-	}
 	userWipBranch, userWipBranchSet := os.LookupEnv("MOB_WIP_BRANCH")
 	if userWipBranchSet {
 		wipBranch = userWipBranch
@@ -73,6 +68,9 @@ func main() {
 		fmt.Println("command '" + command + "'")
 		fmt.Println("parameter '" + strings.Join(parameter, " ") + "'")
 	}
+
+	// set the baseBranch to the currently active branch
+	baseBranch = silentgit("symbolic-ref", "--short", "HEAD")
 
 	if command == "s" || command == "start" {
 		start(parameter)

--- a/mob.go
+++ b/mob.go
@@ -11,7 +11,7 @@ import (
 )
 
 var wipBranch = "mob-session"               // override with MOB_WIP_BRANCH environment variable
-var baseBranch = ""            				// will be set on start
+var baseBranch = ""                         // will be set on start
 var remoteName = "origin"                   // override with MOB_REMOTE_NAME environment variable
 var wipCommitMessage = "mob next [ci-skip]" // override with MOB_WIP_COMMIT_MESSAGE environment variable
 var mobNextStay = false                     // override with MOB_NEXT_STAY environment variable


### PR DESCRIPTION
instead of using the default "master" or the environment variable MOB_BASE_BRANCH, we get the currently checked-out branch from git and set it as the baseBranch.

Solves #14 