### PR TITLE
Run the install script in the correct environment

### DIFF
--- a/install
+++ b/install
@@ -1,3 +1,4 @@
+#! /usr/bin/env bash
 target=/usr/local/bin/
 go build mob.go && cp -f mob $target
 echo "installed 'mob' to $target"


### PR DESCRIPTION
My default shell is not bash compatible and the install script failed. The shebang would guarantee a correct interpreter being used.