### PR TITLE
Always commit the "mob next" commit with --no-verify to skip pre-commit hooks

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -190,7 +190,7 @@ func next() {
 		sayInfo("nothing was done, so nothing to commit")
 	} else {
 		git("add", "--all")
-		git("commit", "--message", "\""+wipCommitMessage+"\"")
+		git("commit", "--message", "\""+wipCommitMessage+"\"", "--no-verify")
 		changes := getChangesOfLastCommit()
 		git("push", remoteName, wipBranch)
 		say(changes)
@@ -221,7 +221,7 @@ func done() {
 	if hasMobbingBranchOrigin() {
 		if !isNothingToCommit() {
 			git("add", "--all")
-			git("commit", "--message", "\""+wipCommitMessage+"\"")
+			git("commit", "--message", "\""+wipCommitMessage+"\"", "--no-verify")
 		}
 		git("push", remoteName, wipBranch)
 


### PR DESCRIPTION
Hi @simonharrer,

thanks for creating the remote mob programming tool.

When we started using it, we quickly ran into the issue that the `mob next` commits were rejected by our rather strict git pre-commit hook. Since we don't want to get rid of the hook and you mentioned [here](https://github.com/remotemobprogramming/mob/pull/16#issuecomment-599636689) that you agree that always using `--no-verify` makes a lot of sense for work-in-progress commit, I've add the (hard-coded) flag.  Making it a configurable option is imho not worth the added complexity.