### PR TITLE
Only print "success" when successfully installed

### DIFF
--- a/install
+++ b/install
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
 target=/usr/local/bin/
-go build mob.go && cp -f mob $target
-echo "installed 'mob' to $target"
+go build mob.go &&
+    cp -f mob "$target" &&
+    echo "installed 'mob' to $target"


### PR DESCRIPTION
When I tried to install `mob`, I got a bunch of Go compiler warnings, but it still said it installed `mob`. This was pretty confusing.

This change conditions the "success" message on the successful compilation and copying of the compiled file.