### PR TITLE
Rephrase zoom screenshare section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ sh -c "$(curl -s https://raw.githubusercontent.com/remotemobprogramming/mob/mast
 
 ### Zoom Screenshare
 
-The `mob share` feature only works if you activate make the screenshare hotkey in zoom globally available, and keep the default shortcut at CMD+SHIFT+S (macOS)/ ALT+S (Linux).
+The `mob share` feature uses the zoom keyboard shortcut "Start/Stop Screen Sharing". This only works if you
+- make the shortcut globally available (Zoom > Preferences > Keyboard Shortcuts), and
+- keep the default shortcut at CMD+SHIFT+S (macOS)/ ALT+S (Linux).
 
 ## More on Installation
 


### PR DESCRIPTION
I tried to make Direct Share global which does not have such a checkbox.

Mentioning the shortcut name explicitly might help others.

@jlangr gave me the tip how to solve this
https://twitter.com/jlangr/status/1255853376891322368?s=20