### PR TITLE
Windows git bash installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Swift [git handover](https://www.remotemobprogramming.org/#git-handover) with 'm
 - `mob` creates WIP commits on the `mob-session` branch
 - `mob` notifies you when it's time to handover
 
-[__TOC__]
-
 ## How to install
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Swift [git handover](https://www.remotemobprogramming.org/#git-handover) with 'm
 - `mob` creates WIP commits on the `mob-session` branch
 - `mob` notifies you when it's time to handover
 
+[__TOC__]
+
 ## How to install
 
 ```
@@ -91,6 +93,15 @@ Create a little script in your `$PATH` called `say` with the following content:
 ```bash
 #!/bin/sh
 espeak -v us-mbrola-1 "$@"
+```
+
+eSpeak NG works even on a MINGW64 installation such as **Git-Bash under Windows**
+(assuming you have [installed the binary through their MSI](https://github.com/espeak-ng/espeak-ng/releases)):
+
+```bash
+#!/bin/sh
+# eSpeak does not set any path, so we specify its installation directory instead
+"$PROGRAMFILES/eSpeak NG/espeak-ng" "$@"
 ```
 
 ## How to configure

--- a/README.md
+++ b/README.md
@@ -93,8 +93,16 @@ Create a little script in your `$PATH` called `say` with the following content:
 espeak -v us-mbrola-1 "$@"
 ```
 
-eSpeak NG works even on a MINGW64 installation such as **Git-Bash under Windows**
-(assuming you have [installed the binary through their MSI](https://github.com/espeak-ng/espeak-ng/releases)):
+### Windows Timer
+
+To get the timer to play "mob next" on your speakers when your time is up, you'll need an installed speech engine.
+We recommand that you install [eSpeak NG for Windows through the MSI](https://github.com/espeak-ng/espeak-ng/releases)
+as it is open source, platform independent and produces quiet a good quality.
+
+Also please note that the speech support **will only work in a MINGW environment**, such
+as `git-bash` as the timer functionality needs a *NIX shell.
+
+Create a little script in `$USERPROFILE/bin` called `say` with the following content:
 
 ```bash
 #!/bin/sh
@@ -137,7 +145,8 @@ Open an issue or create a pull request.
 
 Developed and maintained by [Dr. Simon Harrer](https://twitter.com/simonharrer).
 
-Contributions and testing by Jochen Christ, Martin Huber, Franziska Dessart, and Nikolas Hermann. Thank you!
+Contributions and testing by Jochen Christ, Martin Huber, Franziska Dessart, Nikolas Hermann
+and Christoph Welcz. Thank you!
 
 Logo designed by [Sonja Scheungrab](https://twitter.com/multebaerr).
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 target=/usr/local/bin
 user_arg=$1
 stream_cmd="curl -sL install.mob.sh"
-readme_say="https://mob.sh#linux-timer"
+readme="https://mob.sh"
 
 determine_os() {
   case "$(uname -s)" in
@@ -104,7 +104,7 @@ check_say() {
     echo "While 'mob' will still work, you won't get any spoken indication that your time is up."
     echo "Please refer to the documentation how to setup text to speech on a *NIX system."
     echo
-    echo "$readme_say"
+    echo "$readme#$(determine_os)-timer"
     echo
   fi
 }

--- a/install.sh
+++ b/install.sh
@@ -85,7 +85,7 @@ install_remote_binary() {
     grep "browser_download_url.*mob_.*$(determine_os)_amd64\.tar\.gz" |
     cut -d ":" -f 2,3 |
     tr -d ' \"')
-  curl -ksSL "$url" | tar xz -C "$target" "$(determine_mob_binary)" && chmod +x "$target"/mob
+  curl -sSL "$url" | tar xz -C "$target" "$(determine_mob_binary)" && chmod +x "$target"/mob
 }
 
 display_success() {


### PR DESCRIPTION
Rationale: 

While using the WSL is a nice alternative, not everyone can install it (company policies, availability of the hypervisor, etc). As most Windows devs should have a git installation (if not, they can't work with `mob` anyways :wink:) it would be nice support installing mob via the git-bash that comes bundled with it.

Pros:

* no extra effort required for maintaining a install.cmd script
* user can install mob very easily
* shell syntax much better than the horrible Batch syntax
* external tools in the installer such as tar, tr, curl also bundled within git-bash
* no GoLang binary required for installing mob

Cons: 

* user feels comfortable in Windows and does not move to a better OS, such as OSX or Linux :wink:  
* PowerShell might be a feasible alternative. But it has still the problem of maintaining 3 different installers (brew, *NIX sh, windows)

TODOs:

* [x] testing
* [x] consider if the install.cmd script should be removed entirely