### PR TITLE
fixed user flag for non-windows systems

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ determine_user_install() {
     echo "--user"
     ;;
   *)
-    $user_arg
+    echo "$user_arg"
     ;;
   esac
 }


### PR DESCRIPTION
There is a slight error in the installer that makes it impossible to install mob into user space. I fixed it here