### PR TITLE
Scoop installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -sL install.mob.sh | sh
 ```
 If you are under Windows, you can use `git bash` to install `mob`.
 
-Alternatively, if you use [Scoop](https://scoop.netlify.app/) (alernative to chocolatey, "brew for Windows") then just download the mob.json file, open a PowerShell terminal in that directory and:
+If you use [Scoop](https://scoop.netlify.app/) (alernative to chocolatey, "brew for Windows") then just download the mob.json file, open a PowerShell terminal in that directory and:
 ```
 scoop install mob
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Swift [git handover](https://www.remotemobprogramming.org/#git-handover) with 'm
 ```
 curl -sL install.mob.sh | sh
 ```
-If you are under Windows, you should use `git bash` to install `mob`.
+If you are under Windows, you can use `git bash` to install `mob`.
+
+Alternatively, if you use [Scoop](https://scoop.netlify.app/) (alernative to chocolatey, "brew for Windows") then just download the mob.json file, open a PowerShell terminal in that directory and:
+```
+scoop install mob
+```
+
 
 You can also install it on macOS via homebrew: 
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ Swift [git handover](https://www.remotemobprogramming.org/#git-handover) with 'm
 ```
 curl -sL install.mob.sh | sh
 ```
-If you are under Windows, you can use `git bash` to install `mob`.
-
-If you use [Scoop](https://scoop.netlify.app/) (alernative to chocolatey, "brew for Windows") then just download the mob.json file, open a PowerShell terminal in that directory and:
-```
-scoop install mob
-```
-
+If you are under Windows, you can use `git bash` to install `mob`. 
 
 You can also install it on macOS via homebrew: 
 
@@ -86,6 +80,13 @@ Still, that keyboard shortcut to toggle screen sharing in Zoom is still very hel
 
 ## More on Installation
 
+### Scoop
+
+On Windows, if you use [Scoop](https://scoop.netlify.app/) then just download the mob.json file, open a PowerShell terminal in that directory and:
+```
+scoop install mob
+```
+
 ### Linux Timer
 
 To get the timer to play "mob next" on your speakers when your time is up, you'll need an installed speech engine. 
@@ -126,6 +127,7 @@ Override default value just for a single call:
 ```bash
 MOB_DEBUG=true mob next
 ```
+
 
 ## How to contribute
 

--- a/mob.json
+++ b/mob.json
@@ -1,0 +1,10 @@
+{
+  "version": "0.0.24",
+  "homepage": "https://github.com/remotemobprogramming/mob",
+  "checkver": "github",
+  "url": "https://github.com/remotemobprogramming/mob/releases/latest",
+  "extract_dir": "mob-githandover",
+  "hash": {
+    "url": "https://github.com/remotemobprogramming/mob/releases/download/v$version/mob_v$version_windows_amd64_checksum.txt"
+  }
+}

--- a/mob.json
+++ b/mob.json
@@ -1,10 +1,6 @@
 {
   "version": "0.0.24",
   "homepage": "https://github.com/remotemobprogramming/mob",
-  "checkver": "github",
-  "url": "https://github.com/remotemobprogramming/mob/releases/latest",
-  "extract_dir": "mob-githandover",
-  "hash": {
-    "url": "https://github.com/remotemobprogramming/mob/releases/download/v$version/mob_v$version_windows_amd64_checksum.txt"
-  }
+  "url": "https://github.com/remotemobprogramming/mob/releases/tag/v0.0.24",
+  "extract_dir": "mob-githandover"
 }


### PR DESCRIPTION
Created a scoop "app manifest" file which will allow Scoop to install mob on Windows. There is more that could be done for more in depth scoop support for versioning , etc, but it's a step towards that - and it works.

Scoop has the concept of buckets, and you can make your own or contribute to them, so this could be something to add to the 'extras' bucket, or possibly create a new one for mobbing / remote work / etc., which would remove the need to get the mob.json file manually.

Also updated the readme and provided a link to the Scoop site for more information.

The link is hard-coded to the 64 bit windows version - there is support to add 32/64 sections if that seems valuable.