### PR TITLE
Add assertions for mob-session branch with qualifier

### DIFF
--- a/mob_test.go
+++ b/mob_test.go
@@ -27,6 +27,9 @@ func TestDetermineBranches(t *testing.T) {
 	assertDetermineBranches(t, "master", "", "", "master", "mob-session")
 	assertDetermineBranches(t, "mob-session", "", "", "master", "mob-session")
 
+	assertDetermineBranches(t, "mob-session", "green", "", "mob-session", "mob/mob-session/green")
+	assertDetermineBranches(t, "mob/mob-session/green", "green", "", "mob-session", "mob/mob-session/green")
+
 	assertDetermineBranches(t, "master", "green", "", "master", "mob/master/green")
 	assertDetermineBranches(t, "mob/master/green", "", "", "master", "mob/master/green")
 


### PR DESCRIPTION
While poking around in this excellent code base, I came across one interesting edge condition that is currently not covered by tests. The behaviour to specify is this;

What shall happen if I am on the branch `mob-session` and specify a branch qualifier of `green`?

* My intuition tells me that `mob-session` should be seen as the `baseBranch` and that `mob/mob-session/green` should be seen as the `wipBranch`. With this solution the function is bijective (there's a 1:1 mapping for all combinations of base and wip branches). 
* Instead, however, the tool reports `master` as the `baseBranch` and `mob/master/green` as the `wipBranch`. This makes the function non-injective (with a qualifier of `green` the branches `mob-session` and `master` both map to `mob/master/green`).

I've attached two assertions for this edge case, but **BEWARE: THE FIRST ASSERTION CURRENTLY FAILS**. To avoid failing builds, don't merge this PR just yet. Think of this PR as a conversation starter instead.

Once we settled on what the behaviour is supposed be, I can change the behaviour accordingly and add it to the pull request. 
