### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+on: [push]
+name: Test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.14.2'
+    - run: git config --global user.email "test@test.test"
+    - run: git config --global user.name "mob test git user"
+    - run: go test

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 ![mob Logo](logo.svg)
 <p align="center">
-    <a href="https://github.com/remotemobprogramming/mob/graphs/contributors" alt="Contributors">
-        <img src="https://img.shields.io/github/contributors/remotemobprogramming/mob" /></a>
-     <a href="https://github.com/remotemobprogramming/mob/releases" alt="Downloads">
-        <img src="https://img.shields.io/github/downloads/remotemobprogramming/mob/total" /></a>
-    <a href="https://github.com/remotemobprogramming/mob/releases" alt="Downloads">
-        <img src="https://img.shields.io/github/downloads/remotemobprogramming/mob/latest/total" /></a>
+  <a href="https://github.com/remotemobprogramming/mob/actions?query=workflow%3ATest" alt="Test Workflow">
+    <img src="https://img.shields.io/github/workflow/status/remotemobprogramming/mob/Test" /></a>
+  <a href="https://github.com/remotemobprogramming/mob/graphs/contributors" alt="Contributors">
+    <img src="https://img.shields.io/github/contributors/remotemobprogramming/mob" /></a>
+  <a href="https://github.com/remotemobprogramming/mob/releases" alt="Downloads">
+    <img src="https://img.shields.io/github/downloads/remotemobprogramming/mob/total" /></a>
+  <a href="https://github.com/remotemobprogramming/mob/releases" alt="Downloads">
+    <img src="https://img.shields.io/github/downloads/remotemobprogramming/mob/latest/total" /></a>
 </p>
 
 Swift [git handover](https://www.remotemobprogramming.org/#git-handover) with 'mob'.


### PR DESCRIPTION
This is a first simple try to adding a CI workflow, that runs all the tests. 
A badge is available here https://img.shields.io/github/workflow/status/remotemobprogramming/mob/ci, so this could help to see if the tests on master are currently passing or failing.

I am not sure, if those tests should also be added to the release workflow. I feel that no commit should make it to master, that is not passing the tests. But I am sure this is strongly opinionated, as I am used to working like this, so feel free to make comments about this. 

I am new to GitHub Actions, but so far I could not find a way of adding the tests to the Release workflow without copy and pasting all of the steps.

Fixes #59 