### PR TITLE
Update mob next to push manual commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Adds flag `--return-to-base-branch` (with shorthand `-r`) to return to base branch on `mob next`. Because 'mob' will change the default behavior from returning to the base branch to staying on the wip branch on `mob next`, this flag provides the inverse operation of `--stay`. If both are provided, the latter one wins.
 - Adds flag `-i` as a shorthand notation for `--include-uncommitted-changes`.
 - Fixes a bug that prevented `mob start` to work when on an outdated the WIP branch 
+- `mob next` push if there are commits but no changes.
 
 # 0.0.24
 - Fixes a bug where mob couldn't handle branch names with the '/' character 

--- a/mob.go
+++ b/mob.go
@@ -498,11 +498,11 @@ func isNothingToCommit() bool {
 	return len(strings.TrimSpace(output)) == 0
 }
 
-func hasLocalCommits(currentWipBranch string) bool {
+func hasLocalCommits(branch string) bool {
 	local := silentgit("for-each-ref", "--format=%(objectname)",
-		"refs/heads/"+currentWipBranch)
+		"refs/heads/"+branch)
 	remote := silentgit("for-each-ref", "--format=%(objectname)",
-		"refs/remotes/"+configuration.RemoteName+"/"+currentWipBranch)
+		"refs/remotes/"+configuration.RemoteName+"/"+branch)
 	return strings.TrimSpace(local) != strings.TrimSpace(remote)
 }
 

--- a/mob.go
+++ b/mob.go
@@ -414,6 +414,7 @@ func next() {
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), configuration.WipBranchQualifier, gitBranches())
 
 	if isNothingToCommit() {
+		git("push", "--no-verify", configuration.RemoteName, currentWipBranch)
 		sayInfo("nothing was done, so nothing to commit")
 	} else {
 		git("add", "--all")

--- a/mob_test.go
+++ b/mob_test.go
@@ -427,7 +427,7 @@ func TestNothingToCommitCreatesNoCommits(t *testing.T) {
 	assertCommits(t, 1)
 }
 
-func TestStartNextPushManualCommit(t *testing.T) {
+func TestStartNextPushManualCommits(t *testing.T) {
 	setup(t)
 
 	setWorkingDir("/tmp/mob/local")
@@ -439,6 +439,29 @@ func TestStartNextPushManualCommit(t *testing.T) {
 	next()
 
 	setWorkingDir("/tmp/mob/localother")
+	start()
+	assertFileExist(t, "example.txt")
+}
+
+func TestStartNextPushManualCommitsFeatureBranch(t *testing.T) {
+	setup(t)
+
+	setWorkingDir("/tmp/mob/local")
+
+	git("checkout", "-b", "feature1")
+	git("push", "origin", "feature1", "--set-upstream")
+	assertOnBranch(t, "feature1")
+	start()
+	assertOnBranch(t, "mob/feature1")
+
+	createFile(t, "example.txt", "content")
+	git("add", "--all")
+	git("commit", "-m", "\"asdf\"")
+	next()
+
+	setWorkingDir("/tmp/mob/localother")
+	git("fetch")
+	git("checkout", "feature1")
 	start()
 	assertFileExist(t, "example.txt")
 }

--- a/mob_test.go
+++ b/mob_test.go
@@ -427,6 +427,22 @@ func TestNothingToCommitCreatesNoCommits(t *testing.T) {
 	assertCommits(t, 1)
 }
 
+func TestStartNextPushManualCommit(t *testing.T) {
+	setup(t)
+
+	setWorkingDir("/tmp/mob/local")
+
+	start()
+	createFile(t, "example.txt", "content")
+	git("add", "--all")
+	git("commit", "-m", "\"asdf\"")
+	next()
+
+	setWorkingDir("/tmp/mob/localother")
+	start()
+	assertFileExist(t, "example.txt")
+}
+
 func TestConflictingMobSessions(t *testing.T) {
 	setup(t)
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -435,7 +435,7 @@ func TestStartNextPushManualCommits(t *testing.T) {
 	start()
 	createFile(t, "example.txt", "content")
 	git("add", "--all")
-	git("commit", "-m", "\"asdf\"")
+	git("commit", "-m", "asdf")
 	next()
 
 	setWorkingDir("/tmp/mob/localother")
@@ -456,7 +456,7 @@ func TestStartNextPushManualCommitsFeatureBranch(t *testing.T) {
 
 	createFile(t, "example.txt", "content")
 	git("add", "--all")
-	git("commit", "-m", "\"asdf\"")
+	git("commit", "-m", "asdf")
 	next()
 
 	setWorkingDir("/tmp/mob/localother")


### PR DESCRIPTION
I implemented this Issue #61 because it's so useful for our usage.
Based on your idea, I fixed mob next to push if the current mob branch and remote commit hash are different.

> On second thought, one could locally check if origin/mob-session and mob-session deviate and only if they point to two different commits initiate a git push.
