### PR TITLE
Continue with next notification command even if the previous failed

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -243,9 +243,9 @@ func startTimer(timerInMinutes string) {
 	case "windows":
 		commandString, err = startCommand("powershell", "-command", "start-process powershell -NoNewWindow -ArgumentList '-command \"sleep "+timerInSeconds+"; (New-Object -ComObject SAPI.SPVoice).Speak(\\\""+voiceMessage+"\\\")\"'")
 	case "darwin":
-		commandString, err = startCommand("sh", "-c", "( sleep "+timerInSeconds+" && "+configuration.VoiceCommand+" \""+voiceMessage+"\" && /usr/bin/osascript -e 'display notification \""+textMessage+"\"')  &")
+		commandString, err = startCommand("sh", "-c", "( sleep "+timerInSeconds+" ; "+configuration.VoiceCommand+" \""+voiceMessage+"\" ; /usr/bin/osascript -e 'display notification \""+textMessage+"\"')  &")
 	case "linux":
-		commandString, err = startCommand("sh", "-c", "( sleep "+timerInSeconds+" && "+configuration.VoiceCommand+" \""+voiceMessage+"\" && /usr/bin/notify-send \""+textMessage+"\")  &")
+		commandString, err = startCommand("sh", "-c", "( sleep "+timerInSeconds+" ; "+configuration.VoiceCommand+" \""+voiceMessage+"\" ; /usr/bin/notify-send \""+textMessage+"\")  &")
 	default:
 		sayError("Cannot start timer at " + runtime.GOOS)
 		return


### PR DESCRIPTION
Hey, love your tool - we're using it since a week back and it's really helping us!

I found that I didn't want the voice notification, only the text notification.
The current implementation doesn't continue with the notification command unless the previous (voice) has finished with an exit code 0, which it doesn't unless you have it configured properly.

My proposed changes include
- run all the commands, voice & text regardless if the previous exited ok
~~- add an additional env variable `MOB_NOTIFY_COMMAND` to allow specifying the notification command~~
~~- a small refactoring related to how commands are collected and executed cross platform~~

The last two changes are moved to a separate PR #80

What do you think?