### PR TITLE
Support to specify notify command

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -259,7 +259,7 @@ func getNotifyCommand(message string) string {
 	}
 }
 
-func executeCommands(commands []string) (err error) {
+func executeCommandsInBackgroundProcess(commands ...string) (err error) {
 	cmds := make([]string, 0)
 	for _,c := range commands {
 		if len(c) > 0 {
@@ -285,11 +285,7 @@ func startTimer(timerInMinutes string) {
 	timeoutInSeconds := timeoutInMinutes * 60
 	timeOfTimeout := time.Now().Add(time.Minute * time.Duration(timeoutInMinutes)).Format("15:04")
 
-	err := executeCommands([]string{
-		getSleepCommand(timeoutInSeconds),
-		getVoiceCommand("mob next"),
-		getNotifyCommand("mob next"),
-	})
+	err := executeCommandsInBackgroundProcess(getSleepCommand(timeoutInSeconds), getVoiceCommand("mob next"), getNotifyCommand("mob next"))
 
 	if err != nil {
 		sayError(fmt.Sprintf("timer couldn't be started on your system (%s)", runtime.GOOS))
@@ -301,9 +297,7 @@ func startTimer(timerInMinutes string) {
 
 func moo() {
 	voiceMessage := "moo"
-	err := executeCommands([]string{
-		getVoiceCommand(voiceMessage),
-	})
+	err := executeCommandsInBackgroundProcess(getVoiceCommand(voiceMessage))
 
 	if err != nil {
 		sayError(fmt.Sprintf("can't run voice command on your system (%s)", runtime.GOOS))

--- a/mob.go
+++ b/mob.go
@@ -81,8 +81,8 @@ func parseEnvironmentVariables(configuration Configuration) Configuration {
 
 	setStringFromEnvVariable(&configuration.RemoteName, "MOB_REMOTE_NAME")
 	setStringFromEnvVariable(&configuration.WipCommitMessage, "MOB_WIP_COMMIT_MESSAGE")
-	setStringFromEnvVariable(&configuration.VoiceCommand, "MOB_VOICE_COMMAND")
-	setStringFromEnvVariable(&configuration.NotifyCommand, "MOB_NOTIFY_COMMAND")
+	setOptionalStringFromEnvVariable(&configuration.VoiceCommand, "MOB_VOICE_COMMAND")
+	setOptionalStringFromEnvVariable(&configuration.NotifyCommand, "MOB_NOTIFY_COMMAND")
 
 	setBoolFromEnvVariable(&configuration.Debug, "MOB_DEBUG")
 	setBoolFromEnvVariable(&configuration.MobNextStay, "MOB_NEXT_STAY")
@@ -94,6 +94,14 @@ func parseEnvironmentVariables(configuration Configuration) Configuration {
 func setStringFromEnvVariable(s *string, key string) {
 	value, set := os.LookupEnv(key)
 	if set && value != "" {
+		*s = value
+		debug("overriding " + key + " =" + *s)
+	}
+}
+
+func setOptionalStringFromEnvVariable(s *string, key string) {
+	value, set := os.LookupEnv(key)
+	if set {
 		*s = value
 		debug("overriding " + key + " =" + *s)
 	}

--- a/mob.go
+++ b/mob.go
@@ -285,7 +285,7 @@ func executeCommandsInBackgroundProcess(commands ...string) (err error) {
 	case "linux":
 		_, err = startCommand("sh", "-c", fmt.Sprintf("(%s) &", strings.Join(cmds, ";")))
 	default:
-		sayError("Cannot start timer at " + runtime.GOOS)
+		sayError(fmt.Sprintf("Cannot execute background commands on your os: %s", runtime.GOOS))
 	}
 	return err
 }


### PR DESCRIPTION
- add an additional env variable `MOB_NOTIFY_COMMAND` to allow specifying the notification command
- a small refactoring related to how commands are collected and executed cross platform