### PR TITLE
After installing, check if the mob binary is at the expected location

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -144,6 +144,15 @@ check_say() {
   esac
 }
 
+check_installation_path() {
+  location="$(command -v mob)"
+  if [ "$location" != "$target/mob" ]; then
+    echo "(!) The installation location doesn't match the location of the mob binary."
+    echo "    This means that the binary that's used is not the binary that has just been installed"
+    echo "    You probably want to delete the binary at $location"
+  fi
+}
+
 main() {
   handle_user_installation
   check_access_rights
@@ -151,6 +160,7 @@ main() {
   add_to_path
   display_success
   check_say
+  check_installation_path
 }
 
 main


### PR DESCRIPTION
I had a manually installed version on my machine that was preferred over the one that was installed by `install.sh`. I didn't notice that for quite a while, because it wasn't obvious from the scripts' output.

This PR adds a check for that and will echo a warning if the `mob` binary ist not at the expected location. I tested it on my machine (Ubuntu 20.04), not sure if this works on all platforms.