### PR TITLE
Ignore branch qualifier when branch is mob-session

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -267,13 +267,9 @@ func determineBranches(branch string, branchQualifier string, branches string) (
 		suffix = preparedBranch[index:]
 	}
 
-	if branch == "mob-session" || branch == "master" {
+	if branch == "master" && branchQualifier == "" || branch == "mob-session" {
 		baseBranch = "master"
-		if branchQualifier != "" {
-			wipBranch = wipBranchPrefix + baseBranch + suffix
-		} else {
-			wipBranch = "mob-session"
-		}
+		wipBranch = "mob-session"
 	} else {
 		baseBranch = strings.ReplaceAll(strings.ReplaceAll(branch, wipBranchPrefix, ""), suffix, "")
 		wipBranch = wipBranchPrefix + baseBranch + suffix

--- a/mob_test.go
+++ b/mob_test.go
@@ -41,6 +41,7 @@ func TestDetermineBranches(t *testing.T) {
 
 	assertDetermineBranches(t, "master", "", "", "master", "mob-session")
 	assertDetermineBranches(t, "mob-session", "", "", "master", "mob-session")
+	assertDetermineBranches(t, "mob-session", "green", "", "master", "mob-session")
 
 	assertDetermineBranches(t, "master", "green", "", "master", "mob/master-green")
 	assertDetermineBranches(t, "mob/master-green", "", "", "master", "mob/master-green")


### PR DESCRIPTION
This pull request is a follow up to #62. 

It changes the code to match this specification from the previous pull request:

> That's why being on mob-session (a wip branch due to backward compatibility reasons) should ignore any --branch green option.

The changes in this pull request will silently ignore the branch (and not warn the user about what exactly is going wrong). I'm not entirely sure how to add that warning or if we even need one. What do you think @simonharrer ?