### PR TITLE
Improve instructions for how to contribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,16 @@ MOB_DEBUG=true mob next
 [Propose your change in an issue](https://github.com/remotemobprogramming/mob/issues) or [directly create a pull request with your improvements](https://github.com/remotemobprogramming/mob/pulls).
 
 ```bash
+# PROJECT_ROOT is the root of the project/repository
+
+cd $PROJECT_ROOT
+
 git version # >= 2.17
 go version # >= 1.15
 
 go build # builds 'mob'
+
+./create-testbed    # creates test assets
 
 go test # runs all tests
 go test -run TestDetermineBranches # runs the single test named 'TestDetermineBranches'

--- a/create-testbed
+++ b/create-testbed
@@ -10,7 +10,7 @@ rm -rf "${localdir}" "${remotedir}"
 mkdir -p "${localdir}" "${remotedir}"
 
 (cd "${remotedir}" && git --bare init)
-(cd "${localdir}" && git clone "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push)
+(cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
 # optional
 localotherdir="${tmpdir}/localother"

--- a/create-testbed
+++ b/create-testbed
@@ -17,4 +17,4 @@ localotherdir="${tmpdir}/localother"
 echo "localotherdir=${localotherdir}"
 rm -rf "${localotherdir}"
 mkdir -p "${localotherdir}"
-(cd "${localotherdir}" && git clone "file://${remotedir}" .)
+(cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" .)

--- a/create-testbed
+++ b/create-testbed
@@ -1,20 +1,31 @@
 #!/bin/bash
 set -e
 
+echo "Creating test assets..."
 tmpdir="/tmp/mob"
 localdir="${tmpdir}/local"
 remotedir="${tmpdir}/remote"
-echo "localdir=${localdir}"
+echo ""
+echo "Root of temporary test assets: ${tmpdir}"
+echo "Path to central repository ('remote'): ${remotedir}"
+echo "Path to clone of central repository ('local'): ${localdir}"
+
 mkdir -p "${localdir}" "${remotedir}"
 rm -rf "${localdir}" "${remotedir}"
 mkdir -p "${localdir}" "${remotedir}"
 
+echo ""
+echo "Creating test repositories..."
 (cd "${remotedir}" && git --bare init)
 (cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
 # optional
+echo ""
+echo "Creating a second mob participant's repository..."
 localotherdir="${tmpdir}/localother"
-echo "localotherdir=${localotherdir}"
+echo "Path to second clone of central repository ('localotherdir'): ${localotherdir}"
 rm -rf "${localotherdir}"
 mkdir -p "${localotherdir}"
 (cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" .)
+
+echo "Done."


### PR DESCRIPTION
When I followed the "How to contribute" instructions as is, I couldn't run the tests. I learned that I need to run the `create-testbed` script, but when I ran that script, it failed. I believe that this PR fixes both problems.