### PR TITLE
Found a way to parameterize the Environment Variable Tests

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -36,11 +36,11 @@ type Configuration struct {
 	MobDoneSquash                     bool   // override with MOB_DONE_SQUASH environment variable
 }
 
-func (c *Configuration) GetMobDoneSquash() bool {
+func (c Configuration) GetMobDoneSquash() bool {
 	return c.MobDoneSquash
 }
 
-func (c *Configuration) GetDebug() bool {
+func (c Configuration) GetDebug() bool {
 	return c.Debug
 }
 

--- a/mob.go
+++ b/mob.go
@@ -36,6 +36,14 @@ type Configuration struct {
 	MobDoneSquash                     bool   // override with MOB_DONE_SQUASH environment variable
 }
 
+func (c *Configuration) GetMobDoneSquash() bool {
+	return c.MobDoneSquash
+}
+
+func (c *Configuration) GetDebug() bool {
+	return c.Debug
+}
+
 func main() {
 	configuration = parseEnvironmentVariables(getDefaultConfiguration())
 	debugInfo("Args '" + strings.Join(os.Args, " ") + "'")
@@ -135,8 +143,8 @@ func setBoolFromEnvVariable(s *bool, key string) {
 		*s = false
 		debugInfo("overriding " + key + " =" + strconv.FormatBool(*s))
 	} else {
-	    sayError("ignoring " + key + " =" + value + " (not a boolean)")
-    }
+		sayError("ignoring " + key + " =" + value + " (not a boolean)")
+	}
 }
 
 func setBoolFromEnvVariableSet(s *bool, changed *bool, key string) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -102,28 +102,31 @@ func TestMobDoneSquashEnvironmentVariableDefault(t *testing.T) {
 
 func TestMobDoneSquashEnvironmentVariableEmpty(t *testing.T) {
 	// ASSUME default setting for mobDoneSquash is true
-	configuration = setEnv("MOB_DONE_SQUASH", "")
-
-	equals(t, true, configuration.MobDoneSquash)
+	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
 }
 
 func TestMobDoneSquashEnvironmentVariableTrue(t *testing.T) {
-	configuration = setEnv("MOB_DONE_SQUASH", "true")
-
-	equals(t, true, configuration.MobDoneSquash)
+	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "true", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
 }
 
 func TestMobDoneSquashEnvironmentVariableFalse(t *testing.T) {
-	configuration = setEnv("MOB_DONE_SQUASH", "false")
-
-	equals(t, false, configuration.MobDoneSquash)
+	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "false", false, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
 }
 
 func TestMobDoneSquashEnvironmentVariableGarbage(t *testing.T) {
 	// ASSUME default setting for mobDoneSquash is true
-	configuration = setEnv("MOB_DONE_SQUASH", "garbage")
+	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "garbage", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
+}
 
-	equals(t, true, configuration.MobDoneSquash)
+func parameterizedEnvVarTest(
+	t *testing.T,
+	variable string,
+	value string,
+	expected interface{},
+	actual func(Configuration) interface{},
+) {
+	configuration = setEnv(variable, value)
+	equals(t, expected, actual(configuration))
 }
 
 func setEnv(variable string, value string) Configuration {

--- a/mob_test.go
+++ b/mob_test.go
@@ -100,33 +100,28 @@ func TestMobDoneSquashEnvironmentVariableDefault(t *testing.T) {
 	equals(t, true, configuration.MobDoneSquash)
 }
 
-func TestMobDoneSquashEnvironmentVariableEmpty(t *testing.T) {
-	// ASSUME default setting for mobDoneSquash is true
-	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
+func TestMobDoneSquashEnvironmentVariable(t *testing.T) {
+	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DONE_SQUASH", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
 }
 
-func TestMobDoneSquashEnvironmentVariableTrue(t *testing.T) {
-	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "true", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
+func expectEnvironmentVariableSetsBooleanConfiguration(t *testing.T, envVar string, defaultValue bool, actual func(Configuration) interface{}) {
+	expectEnvironmentVariableSetsConfiguration(t, envVar, "", defaultValue, actual)
+	expectEnvironmentVariableSetsConfiguration(t, envVar, "true", true, actual)
+	expectEnvironmentVariableSetsConfiguration(t, envVar, "false", false, actual)
+	expectEnvironmentVariableSetsConfiguration(t, envVar, "garbage", defaultValue, actual)
 }
 
-func TestMobDoneSquashEnvironmentVariableFalse(t *testing.T) {
-	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "false", false, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
-}
-
-func TestMobDoneSquashEnvironmentVariableGarbage(t *testing.T) {
-	// ASSUME default setting for mobDoneSquash is true
-	parameterizedEnvVarTest(t, "MOB_DONE_SQUASH", "garbage", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
-}
-
-func parameterizedEnvVarTest(
+func expectEnvironmentVariableSetsConfiguration(
 	t *testing.T,
 	variable string,
 	value string,
 	expected interface{},
 	actual func(Configuration) interface{},
 ) {
-	configuration = setEnv(variable, value)
-	equals(t, expected, actual(configuration))
+	t.Run(variable+"=\""+value+"\"(="+fmt.Sprintf("%t", expected)+")", func(t *testing.T) {
+		configuration = setEnv(variable, value)
+		equals(t, expected, actual(configuration))
+	})
 }
 
 func setEnv(variable string, value string) Configuration {

--- a/mob_test.go
+++ b/mob_test.go
@@ -88,22 +88,18 @@ func TestMobRemoteNameEnvironmentVariableEmptyString(t *testing.T) {
 	equals(t, "origin", configuration.RemoteName)
 }
 
-func TestMobDoneSquashEnvironmentVariableDefault(t *testing.T) {
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
-
-	equals(t, true, configuration.MobDoneSquash)
-}
-
 func TestBooleanEnvironmentVariables(t *testing.T) {
 	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DONE_SQUASH", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
 	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DEBUG", false, func(configuration Configuration) interface{} { return configuration.Debug })
 }
 
 func expectEnvironmentVariableSetsBooleanConfiguration(t *testing.T, envVar string, defaultValue bool, actual func(Configuration) interface{}) {
-	expectEnvironmentVariableSetsConfiguration(t, envVar, "", defaultValue, actual)
-	expectEnvironmentVariableSetsConfiguration(t, envVar, "true", true, actual)
-	expectEnvironmentVariableSetsConfiguration(t, envVar, "false", false, actual)
-	expectEnvironmentVariableSetsConfiguration(t, envVar, "garbage", defaultValue, actual)
+	t.Run(envVar, func(t *testing.T) {
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "", defaultValue, actual)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "true", true, actual)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "false", false, actual)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "garbage", defaultValue, actual)
+	})
 }
 
 func expectEnvironmentVariableSetsConfiguration(

--- a/mob_test.go
+++ b/mob_test.go
@@ -77,13 +77,13 @@ func assertDetermineBranches(t *testing.T, branch string, qualifier string, bran
 }
 
 func TestMobRemoteNameEnvironmentVariable(t *testing.T) {
-	configuration = setEnv("MOB_REMOTE_NAME", "GITHUB")
+	configuration = setEnvironmentVariableAndParseInConfiguration("MOB_REMOTE_NAME", "GITHUB")
 
 	equals(t, "GITHUB", configuration.RemoteName)
 }
 
 func TestMobRemoteNameEnvironmentVariableEmptyString(t *testing.T) {
-	configuration = setEnv("MOB_REMOTE_NAME", "")
+	configuration = setEnvironmentVariableAndParseInConfiguration("MOB_REMOTE_NAME", "")
 
 	equals(t, "origin", configuration.RemoteName)
 }
@@ -110,13 +110,13 @@ func expectEnvironmentVariableSetsConfiguration(
 	expected interface{},
 	actual func() interface{},
 ) {
-	t.Run(variable+"=\""+value+"\"(="+fmt.Sprintf("%t", expected)+")", func(t *testing.T) {
-		configuration = setEnv(variable, value)
+	t.Run(fmt.Sprintf("%s=\"%s\"->(expects:%t)", variable, value, expected), func(t *testing.T) {
+		configuration = setEnvironmentVariableAndParseInConfiguration(variable, value)
 		equals(t, expected, actual())
 	})
 }
 
-func setEnv(variable string, value string) Configuration {
+func setEnvironmentVariableAndParseInConfiguration(variable string, value string) Configuration {
 	os.Setenv(variable, value)
 	defer os.Unsetenv(variable)
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -89,16 +89,17 @@ func TestMobRemoteNameEnvironmentVariableEmptyString(t *testing.T) {
 }
 
 func TestBooleanEnvironmentVariables(t *testing.T) {
-	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DONE_SQUASH", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
-	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DEBUG", false, func(configuration Configuration) interface{} { return configuration.Debug })
+	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DONE_SQUASH", true, configuration.GetMobDoneSquash)
+	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DEBUG", false, configuration.GetDebug)
 }
 
-func expectEnvironmentVariableSetsBooleanConfiguration(t *testing.T, envVar string, defaultValue bool, actual func(Configuration) interface{}) {
+func expectEnvironmentVariableSetsBooleanConfiguration(t *testing.T, envVar string, defaultValue bool, actual func() bool) {
+	unpackBoolAsInterface := func() interface{} { return actual() }
 	t.Run(envVar, func(t *testing.T) {
-		expectEnvironmentVariableSetsConfiguration(t, envVar, "", defaultValue, actual)
-		expectEnvironmentVariableSetsConfiguration(t, envVar, "true", true, actual)
-		expectEnvironmentVariableSetsConfiguration(t, envVar, "false", false, actual)
-		expectEnvironmentVariableSetsConfiguration(t, envVar, "garbage", defaultValue, actual)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "", defaultValue, unpackBoolAsInterface)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "true", true, unpackBoolAsInterface)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "false", false, unpackBoolAsInterface)
+		expectEnvironmentVariableSetsConfiguration(t, envVar, "garbage", defaultValue, unpackBoolAsInterface)
 	})
 }
 
@@ -107,11 +108,11 @@ func expectEnvironmentVariableSetsConfiguration(
 	variable string,
 	value string,
 	expected interface{},
-	actual func(Configuration) interface{},
+	actual func() interface{},
 ) {
 	t.Run(variable+"=\""+value+"\"(="+fmt.Sprintf("%t", expected)+")", func(t *testing.T) {
 		configuration = setEnv(variable, value)
-		equals(t, expected, actual(configuration))
+		equals(t, expected, actual())
 	})
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -76,24 +76,20 @@ func assertDetermineBranches(t *testing.T, branch string, qualifier string, bran
 	equals(t, expectedWip, wipBranch)
 }
 
-func TestEnvironmentVariables(t *testing.T) {
-	os.Setenv("MOB_REMOTE_NAME", "GITHUB")
-	defer os.Unsetenv("MOB_REMOTE_NAME")
+func TestDebugEnvironmentVariableTrue(t *testing.T) {
+	configuration = setEnv("MOB_DEBUG", "true")
 
-	os.Setenv("MOB_DEBUG", "true")
-	defer os.Unsetenv("MOB_DEBUG")
-
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
-
-	equals(t, "GITHUB", configuration.RemoteName)
 	equals(t, true, configuration.Debug)
 }
 
-func TestEnvironmentVariablesEmptyString(t *testing.T) {
-	os.Setenv("MOB_REMOTE_NAME", "")
-	defer os.Unsetenv("MOB_REMOTE_NAME")
+func TestMobRemoteNameEnvironmentVariable(t *testing.T) {
+	configuration = setEnv("MOB_REMOTE_NAME", "GITHUB")
 
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
+	equals(t, "GITHUB", configuration.RemoteName)
+}
+
+func TestMobRemoteNameEnvironmentVariableEmptyString(t *testing.T) {
+	configuration = setEnv("MOB_REMOTE_NAME", "")
 
 	equals(t, "origin", configuration.RemoteName)
 }
@@ -106,40 +102,35 @@ func TestMobDoneSquashEnvironmentVariableDefault(t *testing.T) {
 
 func TestMobDoneSquashEnvironmentVariableEmpty(t *testing.T) {
 	// ASSUME default setting for mobDoneSquash is true
-	os.Setenv("MOB_DONE_SQUASH", "")
-	defer os.Unsetenv("MOB_DONE_SQUASH")
-
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
+	configuration = setEnv("MOB_DONE_SQUASH", "")
 
 	equals(t, true, configuration.MobDoneSquash)
 }
 
 func TestMobDoneSquashEnvironmentVariableTrue(t *testing.T) {
-	os.Setenv("MOB_DONE_SQUASH", "true")
-	defer os.Unsetenv("MOB_DONE_SQUASH")
-
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
+	configuration = setEnv("MOB_DONE_SQUASH", "true")
 
 	equals(t, true, configuration.MobDoneSquash)
 }
 
 func TestMobDoneSquashEnvironmentVariableFalse(t *testing.T) {
-	os.Setenv("MOB_DONE_SQUASH", "false")
-	defer os.Unsetenv("MOB_DONE_SQUASH")
-
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
+	configuration = setEnv("MOB_DONE_SQUASH", "false")
 
 	equals(t, false, configuration.MobDoneSquash)
 }
 
 func TestMobDoneSquashEnvironmentVariableGarbage(t *testing.T) {
 	// ASSUME default setting for mobDoneSquash is true
-	os.Setenv("MOB_DONE_SQUASH", "garbage")
-	defer os.Unsetenv("MOB_DONE_SQUASH")
-
-	configuration = parseEnvironmentVariables(getDefaultConfiguration())
+	configuration = setEnv("MOB_DONE_SQUASH", "garbage")
 
 	equals(t, true, configuration.MobDoneSquash)
+}
+
+func setEnv(variable string, value string) Configuration {
+	os.Setenv(variable, value)
+	defer os.Unsetenv(variable)
+
+	return parseEnvironmentVariables(getDefaultConfiguration())
 }
 
 func TestVersion(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -76,12 +76,6 @@ func assertDetermineBranches(t *testing.T, branch string, qualifier string, bran
 	equals(t, expectedWip, wipBranch)
 }
 
-func TestDebugEnvironmentVariableTrue(t *testing.T) {
-	configuration = setEnv("MOB_DEBUG", "true")
-
-	equals(t, true, configuration.Debug)
-}
-
 func TestMobRemoteNameEnvironmentVariable(t *testing.T) {
 	configuration = setEnv("MOB_REMOTE_NAME", "GITHUB")
 
@@ -100,8 +94,9 @@ func TestMobDoneSquashEnvironmentVariableDefault(t *testing.T) {
 	equals(t, true, configuration.MobDoneSquash)
 }
 
-func TestMobDoneSquashEnvironmentVariable(t *testing.T) {
+func TestBooleanEnvironmentVariables(t *testing.T) {
 	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DONE_SQUASH", true, func(configuration Configuration) interface{} { return configuration.MobDoneSquash })
+	expectEnvironmentVariableSetsBooleanConfiguration(t, "MOB_DEBUG", false, func(configuration Configuration) interface{} { return configuration.Debug })
 }
 
 func expectEnvironmentVariableSetsBooleanConfiguration(t *testing.T, envVar string, defaultValue bool, actual func(Configuration) interface{}) {


### PR DESCRIPTION
Uses [SubTests](https://golang.org/pkg/testing/#hdr-Subtests_and_Sub_benchmarks) to parameterize all expectations for boolean typed environment variables. To test all cases for a single boolean environment variable all it needs is a single line of code.

It indents the cases nicely
![image](https://user-images.githubusercontent.com/5053662/103811931-fc4cbc00-505d-11eb-8571-5dc61ca072f9.png)
Also it does not fail all Tests.
In the following example i have only implemented the default of MOB_DONE_SQUASH wrong
![image](https://user-images.githubusercontent.com/5053662/103812046-33bb6880-505e-11eb-9538-5d40c8ab7ccd.png)
