### PR TITLE
Update scoop manifest

### DIFF
--- a/mob.json
+++ b/mob.json
@@ -1,6 +1,16 @@
 {
-  "version": "0.0.24",
-  "homepage": "https://github.com/remotemobprogramming/mob",
-  "url": "https://github.com/remotemobprogramming/mob/releases/tag/v0.0.24",
-  "extract_dir": "mob-githandover"
+    "version": "1.1.0",
+    "description": "Swift git handover with mob",
+    "homepage": "https://github.com/remotemobprogramming/mob",
+    "license": "MIT",
+    "url": "https://github.com/remotemobprogramming/mob/releases/download/v1.1.0/mob_v1.1.0_windows_amd64.tar.gz",
+    "hash": "md5:f6655da1ac933b326d8155f6cdad911a",
+    "bin": "mob.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/remotemobprogramming/mob/releases/download/v$version/mob_v$version_windows_amd64.tar.gz",
+        "hash": {
+            "url": "$baseurl/mob_v$version_windows_amd64_checksum.txt"
+        }
+    }
 }


### PR DESCRIPTION
- Bump mob from 0.0.24 to 1.1.0
- Add scoop autoupdate url + hash
- Add hash + license + description

I gave the scoop manifest of mob a bit of ❤️  (its now autoupdatable using [checkver.ps1](https://github.com/lukesampson/scoop/wiki/App-Manifest-Autoupdate#updating-manifest) of scoop).
I considered adding mob to the scoop main bucket (and opening a PR there as well) as it's a bit cumbersome to download the json just to install mob using scoop. 
What do you think? 