### PR TITLE
Encapsulate Configuration

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -137,36 +137,17 @@ func setOptionalStringFromEnvVariable(s *string, key string) {
 func setBoolFromEnvWithSetter(setter func(value bool), key string) {
 	env := parseBoolEnv(key)
 	if env != nil {
+		debugInfo("overriding " + key + " =" + strconv.FormatBool(*env))
 		setter(*env)
 	}
 }
 
 func setBoolFromEnvVariable(s *bool, key string) {
 	optionalBool := parseBoolEnv(key)
-
 	if optionalBool != nil {
+		debugInfo("overriding " + key + " =" + strconv.FormatBool(*optionalBool))
 		*s = *optionalBool
 	}
-}
-
-func parseBoolEnv(key string) *bool {
-	var envValue bool
-	var optionalEnvValue *bool
-	value, set := os.LookupEnv(key)
-	if !set || value == "" {
-		debugInfo(key + " not set")
-	} else if value == "true" {
-		envValue = true
-		optionalEnvValue = &envValue
-		debugInfo("overriding " + key + " =" + strconv.FormatBool(envValue))
-	} else if value == "false" {
-		envValue = false
-		optionalEnvValue = &envValue
-		debugInfo("overriding " + key + " =" + strconv.FormatBool(envValue))
-	} else {
-		sayError("ignoring " + key + " =" + value + " (not a boolean)")
-	}
-	return optionalEnvValue
 }
 
 func setBoolFromEnvVariableSet(s *bool, changed *bool, key string) {
@@ -180,6 +161,22 @@ func setBoolFromEnvVariableSet(s *bool, changed *bool, key string) {
 		*changed = true
 		debugInfo("overriding " + key + " =" + strconv.FormatBool(*s))
 	}
+}
+
+func parseBoolEnv(key string) *bool {
+	var envValue bool
+	var optionalEnvValue *bool
+	value, set := os.LookupEnv(key)
+	if set && value != "true" && value != "false" {
+		sayError("ignoring " + key + " =" + value + " (not a boolean)")
+	} else if set && value == "true" {
+		envValue = true
+		optionalEnvValue = &envValue
+	} else if set && value == "false" {
+		envValue = false
+		optionalEnvValue = &envValue
+	}
+	return optionalEnvValue
 }
 
 func removed(key string, message string) {

--- a/mob.go
+++ b/mob.go
@@ -184,7 +184,7 @@ func config() {
 	say("MOB_DEBUG" + "=" + strconv.FormatBool(configuration.Debug))
 	say("MOB_WIP_BRANCH_QUALIFIER" + "=" + configuration.WipBranchQualifier)
 	say("MOB_WIP_BRANCH_QUALIFIER_SEPARATOR" + "=" + configuration.WipBranchQualifierSeparator)
-	say("MOB_DONE_SQUASH" + "=" + strconv.FormatBool(configuration.MobDoneSquash))
+	say("MOB_DONE_SQUASH" + "=" + strconv.FormatBool(configuration.GetMobDoneSquash()))
 }
 
 func parseArgs(args []string) (command string, parameters []string) {
@@ -615,7 +615,7 @@ func done() {
 }
 
 func squashOrNoCommit() string {
-	if configuration.MobDoneSquash {
+	if configuration.GetMobDoneSquash() {
 		return "--squash"
 	} else {
 		return "--no-commit"

--- a/mob_test.go
+++ b/mob_test.go
@@ -26,13 +26,13 @@ func TestParseArgs(t *testing.T) {
 
 func TestParseArgsDoneSquash(t *testing.T) {
 	configuration = getDefaultConfiguration()
-	equals(t, true, configuration.MobDoneSquash)
+	equals(t, true, configuration.GetMobDoneSquash())
 
 	command, parameters := parseArgs([]string{"mob", "done", "--no-squash"})
 
 	equals(t, "done", command)
 	equals(t, "", strings.Join(parameters, ""))
-	equals(t, false, configuration.MobDoneSquash)
+	equals(t, false, configuration.GetMobDoneSquash())
 }
 
 func TestParseArgsMessage(t *testing.T) {


### PR DESCRIPTION
Hi @simonharrer 

I continued the refactoring. Now that we are using the getter for MobDoneSquash I thought it would make sense to only use it.
And that is the first commit.

Then I was thinking about the writes to this config boolean, and to encapsulate it with a Setter.
I'm not a big fan of get/set for properties, but I'm also not a fan of having both ways (with accessor, and without).
And after all, the getter enabled neat testing of the config.

The Setter was a bit trickier, as I had to do a couple of steps and solve a couple of problems.
I had to do a split-phase refactoring in the setBoolFromEnv function and extract a parseBoolFromEnv function that returns an optional boolean.
I managed to represent an optional boolean with a pointer however, I don't like the code yet.
I think an OptionalBoolean type or an Optional monad would be better.
So you see, it's getting a little complicated.
So this is kind of experimental. But still, I think the code could become more expressive in the end.
Let me know how you think about it.
