### PR TITLE
Automatically append `Co-authored-by:` lines after squash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - The list of commits included in a mob branch is now truncated to a maximum of 5 entries to prevent the need for scrolling up in order to see the latest included changes.
 - Show more informative error message when `mob <cmd>` is run outside of a git repository.
 - Add environment variable MOB_TIMER which allows setting a default timer duration for `mob start` and `mob timer` commands.
+- Add automatic co-author attribution. Mob will collect all committers from a WIP branch and add them as co-authors in the final WIP commit.
 
 # 1.3.0
 - The default `MOB_COMMIT_MESSAGE` now includes `[ci skip]` and `[skip ci]` so that all the typical CI systems (including Azure DevOps) will skip this commit.

--- a/coauthors.go
+++ b/coauthors.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Author is a coauthor "Full Name <email>"
+type Author = string
+
+func collectCoauthorsFromWipCommits(file *os.File) []Author {
+	var committer string
+	coauthorsHashSet := make(map[Author]bool)
+
+	authorOrCoauthorMatcher := regexp.MustCompile("(?i).*(author)+.+<+.*>+")
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if authorOrCoauthorMatcher.MatchString(line) {
+			author := stripToAuthor(line)
+
+			// committer of this commit should
+			// not be included as a co-author
+			if committer == "" || author == committer {
+				committer = author
+				continue
+			}
+			coauthorsHashSet[author] = true
+		}
+	}
+
+	coauthors := make([]string, 0, len(coauthorsHashSet))
+
+	for k := range coauthorsHashSet {
+		coauthors = append(coauthors, k)
+	}
+	sort.Sort(byLength(coauthors))
+
+	return coauthors
+}
+
+func appendCoauthorsToSquashMsg(workingDir string) error {
+	squashMsgPath := path.Join(workingDir, ".git", "SQUASH_MSG")
+	file, err := os.OpenFile(squashMsgPath, os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		if err == os.ErrNotExist {
+			// No wip commits, nothing to squash, this isn't really an error
+			return nil
+		}
+		return err
+	}
+
+	defer file.Close()
+
+	coauthors := collectCoauthorsFromWipCommits(file)
+
+	if len(coauthors) > 0 {
+		coauthorSuffix := "\n\n"
+		coauthorSuffix += "# mob automatically added all co-authors from WIP commits\n"
+		coauthorSuffix += "# add missing co-authors manually\n"
+
+		coauthorSuffix += coauthorsForCommitMsg(coauthors)
+
+		writer := bufio.NewWriter(file)
+		_, err = writer.WriteString(coauthorSuffix)
+		err = writer.Flush()
+	}
+
+	return err
+}
+
+func coauthorsForCommitMsg(coauthors []Author) string {
+	var commitMsg string
+
+	for _, coauthor := range coauthors {
+		commitMsg += fmt.Sprintf("Co-authored-by: %s\n", coauthor)
+	}
+
+	return commitMsg
+}
+
+type byLength []string
+
+func (s byLength) Len() int {
+	return len(s)
+}
+func (s byLength) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s byLength) Less(i, j int) bool {
+	return len(s[i]) < len(s[j])
+}
+
+func stripToAuthor(line string) string {
+	return strings.TrimSpace(strings.Join(strings.Split(line, ":")[1:], ""))
+}
+

--- a/coauthors.go
+++ b/coauthors.go
@@ -14,7 +14,16 @@ import (
 type Author = string
 
 func collectCoauthorsFromWipCommits(file *os.File) []Author {
-	var committer string
+	// Here we parse the SQUASH_MSG file for the list of authors on
+	// the WIP branch.  If this technique later turns out to be
+	// problematic, an alternative would be to instead fetch the
+	// authors' list from the git log, using e.g.:
+	//
+	// silentgit("log", fmt.Sprintf("%s..", currentBaseBranch), "--reverse", "--pretty=format:%an <%ae>")
+	//
+	// For details and background, see https://github.com/remotemobprogramming/mob/issues/81
+
+	committerEmail := gitUserEmail()
 	coauthorsHashSet := make(map[Author]bool)
 
 	authorOrCoauthorMatcher := regexp.MustCompile("(?i).*(author)+.+<+.*>+")
@@ -27,8 +36,7 @@ func collectCoauthorsFromWipCommits(file *os.File) []Author {
 
 			// committer of this commit should
 			// not be included as a co-author
-			if committer == "" || author == committer {
-				committer = author
+			if strings.Contains(author, committerEmail) {
 				continue
 			}
 			coauthorsHashSet[author] = true
@@ -100,4 +108,3 @@ func (s byLength) Less(i, j int) bool {
 func stripToAuthor(line string) string {
 	return strings.TrimSpace(strings.Join(strings.Split(line, ":")[1:], ""))
 }
-

--- a/coauthors_test.go
+++ b/coauthors_test.go
@@ -7,6 +7,11 @@ import (
 func TestStartDoneCoAuthors(t *testing.T) {
 	setup(t)
 
+	setWorkingDir("/tmp/mob/alice")
+	start(configuration)
+	createFile(t, "file3.txt", "owqe")
+	next(configuration)
+
 	setWorkingDir("/tmp/mob/local")
 	start(configuration)
 	createFile(t, "file1.txt", "asdf")
@@ -15,11 +20,6 @@ func TestStartDoneCoAuthors(t *testing.T) {
 	setWorkingDir("/tmp/mob/localother")
 	start(configuration)
 	createFile(t, "file2.txt", "asdf")
-	next(configuration)
-
-	setWorkingDir("/tmp/mob/alice")
-	start(configuration)
-	createFile(t, "file3.txt", "owqe")
 	next(configuration)
 
 	setWorkingDir("/tmp/mob/alice")
@@ -34,7 +34,6 @@ func TestStartDoneCoAuthors(t *testing.T) {
 
 	setWorkingDir("/tmp/mob/local")
 	start(configuration)
-	createFile(t, "file6.txt", "oiuo")
 	done(configuration)
 
 	output := run(t, "cat", "/tmp/mob/local/.git/SQUASH_MSG")
@@ -43,4 +42,3 @@ func TestStartDoneCoAuthors(t *testing.T) {
 	// include everyone else in commit order after removing duplicates
 	assertOutputContains(t, output, "\nCo-authored-by: bob <bob@example.com>\nCo-authored-by: alice <alice@example.com>\nCo-authored-by: localother <localother@example.com>\n")
 }
-

--- a/coauthors_test.go
+++ b/coauthors_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestStartDoneCoAuthors(t *testing.T) {
+	setup(t)
+
+	setWorkingDir("/tmp/mob/local")
+	start(configuration)
+	createFile(t, "file1.txt", "asdf")
+	next(configuration)
+
+	setWorkingDir("/tmp/mob/localother")
+	start(configuration)
+	createFile(t, "file2.txt", "asdf")
+	next(configuration)
+
+	setWorkingDir("/tmp/mob/alice")
+	start(configuration)
+	createFile(t, "file3.txt", "owqe")
+	next(configuration)
+
+	setWorkingDir("/tmp/mob/alice")
+	start(configuration)
+	createFile(t, "file4.txt", "zcvx")
+	next(configuration)
+
+	setWorkingDir("/tmp/mob/bob")
+	start(configuration)
+	createFile(t, "file5.txt", "oiuo")
+	next(configuration)
+
+	setWorkingDir("/tmp/mob/local")
+	start(configuration)
+	createFile(t, "file6.txt", "oiuo")
+	done(configuration)
+
+	output := run(t, "cat", "/tmp/mob/local/.git/SQUASH_MSG")
+	// don't include the person running `mob done`
+	assertOutputNotContains(t, output, "Co-authored-by: local <local@example.com>")
+	// include everyone else in commit order after removing duplicates
+	assertOutputContains(t, output, "\nCo-authored-by: bob <bob@example.com>\nCo-authored-by: alice <alice@example.com>\nCo-authored-by: localother <localother@example.com>\n")
+}
+

--- a/create-testbed
+++ b/create-testbed
@@ -1,31 +1,45 @@
 #!/bin/bash
 set -e
 
-echo "Creating test assets..."
-tmpdir="/tmp/mob"
-localdir="${tmpdir}/local"
+createrepo() {
+    dir=$1
+    name=$(basename $dir)
+    echo ""
+    echo "Cloning remote to ${dir}"
+    rm -rf "${dir}"
+    mkdir -p "${dir}"
+    (cd "${dir}" && git clone --origin origin "file://${remotedir}" .)
+    (cd "${dir}" && git config --local user.name ${name})
+    (cd "${dir}" && git config --local user.email ${name}@example.com)
+}
+
+# create base dir
+tmpdir="/tmp/mob" # XXX this should be more unique
+echo ""
+echo "Creating temporary test assets in ${tmpdir}"
+rm -rf "${tmpdir}" # XXX this is dangerous unless tmpdir is unique
+mkdir ${tmpdir}
+
+# create remote repo
 remotedir="${tmpdir}/remote"
 echo ""
-echo "Root of temporary test assets: ${tmpdir}"
-echo "Path to central repository ('remote'): ${remotedir}"
-echo "Path to clone of central repository ('local'): ${localdir}"
-
-mkdir -p "${localdir}" "${remotedir}"
-rm -rf "${localdir}" "${remotedir}"
-mkdir -p "${localdir}" "${remotedir}"
-
-echo ""
-echo "Creating test repositories..."
+echo "Creating remote repository ${remotedir}"
+rm -rf "${remotedir}"
+mkdir -p "${remotedir}"
 (cd "${remotedir}" && git --bare init)
-(cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
-# optional
-echo ""
-echo "Creating a second mob participant's repository..."
-localotherdir="${tmpdir}/localother"
-echo "Path to second clone of central repository ('localotherdir'): ${localotherdir}"
-rm -rf "${localotherdir}"
-mkdir -p "${localotherdir}"
-(cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" .)
+# create first local repo
+localdir="${tmpdir}/local"
+createrepo "${localdir}"
+# populate an initial import
+echo "Populating and pushing"
+(cd "${localdir}" && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
+
+# create more local repos
+for name in localother alice bob
+do
+    createrepo "${tmpdir}/${name}"
+done
+
 
 echo "Done."

--- a/create-testbed
+++ b/create-testbed
@@ -17,8 +17,7 @@ createrepo() {
 tmpdir="/tmp/mob" # XXX this should be more unique
 echo ""
 echo "Creating temporary test assets in ${tmpdir}"
-rm -rf "${tmpdir}" # XXX this is dangerous unless tmpdir is unique
-mkdir ${tmpdir}
+mkdir -p ${tmpdir}
 
 # create remote repo
 remotedir="${tmpdir}/remote"
@@ -31,6 +30,7 @@ mkdir -p "${remotedir}"
 # create first local repo
 localdir="${tmpdir}/local"
 createrepo "${localdir}"
+
 # populate an initial import
 echo "Populating and pushing"
 (cd "${localdir}" && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)

--- a/mob.go
+++ b/mob.go
@@ -648,7 +648,7 @@ func getCachedChanges() string {
 func makeWipCommit() {
 	commitMsg := configuration.WipCommitMessage
 	git("add", "--all")
-	git("commit", "--allow-empty", "--message", commitMsg, "--no-verify")
+	git("commit", "--message", commitMsg, "--no-verify")
 }
 
 func done(configuration Configuration) {

--- a/mob.go
+++ b/mob.go
@@ -797,6 +797,10 @@ func gitUserName() string {
 	return strings.TrimSpace(silentgit("config", "--get", "user.name"))
 }
 
+func gitUserEmail() string {
+	return strings.TrimSpace(silentgit("config", "--get", "user.email"))
+}
+
 func showNext(configuration Configuration) {
 	debugInfo("determining next person based on previous changes")
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"errors"
-	fmt "fmt"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
In draft mode for discussion:

- fixes #81
- includes a TestStartDoneCoAuthors() test case
- includes a refactored create-testbed that adds more local repos and sets unique committers in each to exercise coauthors code

Implementation in mob.go will need (approximately):

- an appendCoAuthors() function, called by done(), modeled after the bash code in https://github.com/remotemobprogramming/mob/issues/81#issuecomment-770440672 
  - include a "Co-authored-by: Dustin McQuay <dmcquay@gmail.com>" header in this commit
- a gitLogCoAuthors() function, modeled after gitBranches(), called by appendCoAuthors().  We would call the following `git log` command to get the list of authors on the mob branch, splitting each resulting line on comma to get the username and email.  We would also need to remove duplicates from the resulting list, and would need to remove the user who is running `mob done` before returning the list to appendCoAuthors().
```
runCommand("git",  "log", fmt.Sprintf("%s..", currentBaseBranch), "--reverse", "--pretty=format:%an,%ae")
```
- a gitUserEmail() function, modeled after gitUserName(), both called by gitLogCoAuthors(), so we can remove the current user from the coauthors list

I'll recommend that we write a separate test case for each of the above, starting from the bottom, before implementing each.

If there are no objections, I'd like to change the `/tmp/mob` basedir used for testing. To reduce risk, this should either be in e.g. a ./var directory that is in .gitignore, or if it must for some reason be in /tmp then we ought to use a `tempfile`-style algorithm to prevent collisions.  An idiomatic method would be to call t.TempDir() and pass that path to create-testbed.

If create-testbed needs to be touched much more, it may make sense to port it to Go and move it into mob_test.go -- that would also get rid of the duplication of hardcoded paths between those two files.  I'm thinking we should try to avoid that extra work for this PR though.

We'll work this locally when it comes up in our mobbing queue, and I'll also keep an eye on pull requests against https://github.com/t7a/mob/tree/append-coauthors in case anyone else wants to add commits.