### PR TITLE
Truncate list of last commits if it is longer than 5 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.4.0
+- The list of commits included in a mob branch is now truncated to a maximum of 5 entries to prevent the need for scrolling up in order to see the latest included changes.
+
 # 1.3.0
 - The default `MOB_COMMIT_MESSAGE` now includes `[ci skip]` and `[skip ci]` so that all the typical CI systems (including Azure DevOps) will skip this commit.
 - Add `--squash` option to `mob done` that corresponds to `--no-squash`.

--- a/mob.go
+++ b/mob.go
@@ -688,7 +688,7 @@ func status() {
 		currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
 		sayInfo("on wip branch " + currentWipBranch + " (base branch " + currentBaseBranch + ")")
 
-		say(silentgit("--no-pager", "log", currentBaseBranch+".."+currentWipBranch, "--pretty=format:%h %cr <%an>", "--abbrev-commit"))
+		sayLastCommitsList(currentBaseBranch, currentWipBranch)
 	} else {
 		sayInfo("you aren't mob programming")
 		currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
@@ -696,6 +696,17 @@ func status() {
 
 		sayTodo("to start mob programming, use", "mob start")
 	}
+}
+
+func sayLastCommitsList(currentBaseBranch string, currentWipBranch string) {
+	log := silentgit("--no-pager", "log", currentBaseBranch+".."+currentWipBranch, "--pretty=format:%h %cr <%an>", "--abbrev-commit")
+	lines := strings.Split(strings.TrimSpace(log), "\n")
+	if len(lines) > 5 {
+		sayInfo("This mob branch contains " + strconv.Itoa(len(lines)) + " commits. The last 5 were:")
+		lines = lines[:5]
+	}
+	output := strings.Join(lines, "\n")
+	say(output)
 }
 
 func isNothingToCommit() bool {

--- a/mob_test.go
+++ b/mob_test.go
@@ -282,6 +282,21 @@ func TestStatusMobProgramming(t *testing.T) {
 	assertOutputContains(t, output, "you are mob programming")
 }
 
+func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
+	setup(t)
+	configuration.MobNextStay = true
+	start(configuration)
+
+	for i := 0; i < 6; i++ {
+		createFile(t, "test"+strconv.Itoa(i)+".txt", "test")
+		next(configuration)
+	}
+
+	output := captureOutput()
+	status()
+	assertOutputContains(t, output, "This mob branch contains 6 commits.")
+}
+
 func TestExecuteKicksOffStatus(t *testing.T) {
 	output := setup(t)
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -297,6 +297,16 @@ func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
 	assertOutputContains(t, output, "This mob branch contains 6 commits.")
 }
 
+func TestStatusDoesNotAddEmptyLineFor0Commits(t *testing.T) {
+	setup(t)
+	start(configuration)
+	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
+
+	output := captureOutput()
+	sayLastCommitsList(currentBaseBranch, currentWipBranch)
+	assertOutputNotContains(t, output, "\n")
+}
+
 func TestExecuteKicksOffStatus(t *testing.T) {
 	output := setup(t)
 


### PR DESCRIPTION
See https://twitter.com/Morl99/status/1365360716610478080 for the discussion about the feature

I am very new to go and would happily take any comments about how this code could be simpler, if possible. 
I decided to write a test for the "happy" case, where the new code actually makes any difference, and decided that for everything else, the existing tests are good enough.

@simonharrer do you think that this should be configurable behaviour? Can you think of a use case, where mob should consistently print the whole list, or more than 5 entries? 

PS: I was unable to execute the commans that are documented in the "How to contribute section", as Go always complained about a missing module. I readded the module file that you created yesterday and it worked like a charm. I am using go 1.16, not sure if this has anything to do with it. Just wanted to let you know, I did not commit go.mod because I do not want to mess with your project setup.