### PR TITLE
Upgrade to Go 1.16 using Go Module

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.16'
     - run: git config --global user.email "test@test.test"
     - run: git config --global user.name "mob test git user"
-    - run: go test
-
+    - name: Use Go 1.16 to test
+      uses: cedrickring/golang-action/go1.16@1.7.0
+      with:
+        args: go test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,8 +5,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: git config --global user.email "test@test.test"
-    - run: git config --global user.name "mob test git user"
     - name: Use Go 1.16 to test
       uses: cedrickring/golang-action/go1.16@1.7.0
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15'
+        go-version: '1.16'
     - run: git config --global user.email "test@test.test"
     - run: git config --global user.name "mob test git user"
     - run: go test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - run: git config --global user.email "test@test.test"
-      - run: git config --global user.name "${{github.actor}}"
       - name: Use Go 1.16 to test
         uses: cedrickring/golang-action/go1.16@1.7.0
         with:
@@ -25,7 +23,9 @@ jobs:
       - name: Use Go 1.16 to build
         uses: cedrickring/golang-action/go1.16@1.7.0
         with:
-          args: go build
+          args: go build -o mob${{ matrix.os == 'windows' && '.exe' || '' }}
+        env:
+          GOOS: ${{ matrix.os }}
       - name: Create release artifacts using .github/build
         run: .github/build
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,6 @@ jobs:
       matrix:
         os: [linux, darwin, windows]
     env:
-      GOPATH: ${{ github.workspace }}
       GOARCH: amd64
       GOOS: ${{ matrix.os }}
     name: release
@@ -17,11 +16,14 @@ jobs:
       - uses: actions/checkout@main
       - run: git config --global user.email "test@test.test"
       - run: git config --global user.name "${{github.actor}}"
-      - run: go test
+      - name: Use Go 1.16 to test
+        uses: cedrickring/golang-action/go1.16@1.7.0
+        with:
+          args: go test
         env:
           GOOS: linux # the tests will only run if the os matches the os of the system of run-on
-      - name: Use Go 1.15 to build
-        uses: cedrickring/golang-action/go1.15@1.6.0
+      - name: Use Go 1.16 to build
+        uses: cedrickring/golang-action/go1.16@1.7.0
         with:
           args: go build
       - name: Create release artifacts using .github/build

--- a/create-testbed
+++ b/create-testbed
@@ -17,7 +17,7 @@ mkdir -p "${localdir}" "${remotedir}"
 echo ""
 echo "Creating test repositories..."
 (cd "${remotedir}" && git --bare init)
-(cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
+(cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && git config --local user.name "Test User 1" && git config --local user.email "test@test.test" && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
 # optional
 echo ""
@@ -26,6 +26,6 @@ localotherdir="${tmpdir}/localother"
 echo "Path to second clone of central repository ('localotherdir'): ${localotherdir}"
 rm -rf "${localotherdir}"
 mkdir -p "${localotherdir}"
-(cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" .)
+(cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" . && git config --local user.name "Test User 2" && git config --local user.email "test2@test.test")
 
 echo "Done."

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module mob.sh
+
+go 1.16


### PR DESCRIPTION
This should fix #127 fix #134 and fix #98 

I simplified the actions by moving the git config part to the create-testbed script. I think this reflects, that the git config is indeed a requirement for successfully running the tests. This allows to use the golang actions for the tests as well. Since the actions are run in separate docker containers, there is no way to run the git config commands through the action. The benefit of this is, that the ci action is now very similar to what happens during the release, so potential errors could be caught well before an actual release is created.I have sucessfully created a test release in my fork, check it out here: https://github.com/Morl99/mob/releases/tag/1.3.5

Let me know if that makes sense to you or if you'd want to change something.