### PR TITLE
refactor create-testbed to create more repos

### DIFF
--- a/create-testbed
+++ b/create-testbed
@@ -1,31 +1,49 @@
 #!/bin/bash
 set -e
 
-echo "Creating test assets..."
-tmpdir="/tmp/mob"
+createrepo() {
+    dir=$1
+    name=$(basename $dir)
+    echo ""
+    echo "Cloning remote to ${dir}"
+    rm -rf "${dir}"
+    mkdir -p "${dir}"
+    (cd "${dir}" && git clone --origin origin "file://${remotedir}" .)
+    (cd "${dir}" && git config --local user.name ${name})
+    (cd "${dir}" && git config --local user.email ${name}@example.com)
+}
+
+tmpdir="/tmp/mob" # XXX this should be more unique
 localdir="${tmpdir}/local"
 remotedir="${tmpdir}/remote"
-echo ""
-echo "Root of temporary test assets: ${tmpdir}"
-echo "Path to central repository ('remote'): ${remotedir}"
-echo "Path to clone of central repository ('local'): ${localdir}"
+notgit="${tmpdir}/notgit"
 
-mkdir -p "${localdir}" "${remotedir}"
-rm -rf "${localdir}" "${remotedir}"
-mkdir -p "${localdir}" "${remotedir}"
-
+# create base dir
 echo ""
-echo "Creating test repositories..."
+echo "Creating temporary test assets in ${tmpdir}"
+mkdir -p ${tmpdir}
+
+# create remote repo
+echo ""
+echo "Creating remote repository ${remotedir}"
+rm -rf "${remotedir}"
+mkdir -p "${remotedir}"
 (cd "${remotedir}" && git --bare init)
-(cd "${localdir}" && git clone --origin origin "file://${remotedir}" . && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
-# optional
-echo ""
-echo "Creating a second mob participant's repository..."
-localotherdir="${tmpdir}/localother"
-echo "Path to second clone of central repository ('localotherdir'): ${localotherdir}"
-rm -rf "${localotherdir}"
-mkdir -p "${localotherdir}"
-(cd "${localotherdir}" && git clone --origin origin "file://${remotedir}" .)
+# create first local repo
+createrepo "${localdir}"
+
+# populate an initial import
+echo "Populating and pushing"
+(cd "${localdir}" && echo "test" >test.txt && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
+
+# create more local repos
+for name in localother alice bob
+do
+    createrepo "${tmpdir}/${name}"
+done
+
+# create a non-git area
+mkdir -p "${localdir}" "${notgit}"
 
 echo "Done."

--- a/mob_test.go
+++ b/mob_test.go
@@ -510,6 +510,48 @@ func TestStartDoneWithMobDoneSquashTrue(t *testing.T) {
 	assertNoMobSessionBranches(t, "mob-session")
 }
 
+func TestRunOutput(t *testing.T) {
+	setup(t)
+	setWorkingDir("/tmp/mob/local")
+	start()
+	createFile(t, "file1.txt", "asdf")
+	output := run(t, "cat", "/tmp/mob/local/file1.txt")
+	assertOutputContains(t, output, "asdf")
+}
+
+func TestTestbed(t *testing.T) {
+	setup(t)
+
+	setWorkingDir("/tmp/mob/local")
+	start()
+	createFile(t, "file1.txt", "asdf")
+	next()
+
+	setWorkingDir("/tmp/mob/localother")
+	start()
+	createFile(t, "file2.txt", "asdf")
+	next()
+
+	setWorkingDir("/tmp/mob/alice")
+	start()
+	createFile(t, "file3.txt", "owqe")
+	next()
+
+	setWorkingDir("/tmp/mob/bob")
+	start()
+	createFile(t, "file4.txt", "zcvx")
+	next()
+
+	setWorkingDir("/tmp/mob/local")
+	start()
+
+	output := silentgit("log", "--pretty=format:'%ae'")
+	assertOutputContains(t, &output, "local")
+	assertOutputContains(t, &output, "localother")
+	assertOutputContains(t, &output, "alice")
+	assertOutputContains(t, &output, "bob")
+}
+
 func TestStartDoneWithMobDoneSquashFalse(t *testing.T) {
 	setup(t)
 	configuration.MobDoneSquash = false
@@ -799,7 +841,7 @@ func captureOutput() *string {
 	return &messages
 }
 
-func run(t *testing.T, name string, args ...string) {
+func run(t *testing.T, name string, args ...string) *string {
 	commandString, output, err := runCommand(name, args...)
 	if err != nil {
 		fmt.Println(commandString)
@@ -807,6 +849,7 @@ func run(t *testing.T, name string, args ...string) {
 		fmt.Println(err.Error())
 		t.Error("command " + commandString + " failed")
 	}
+	return &output
 }
 
 func createTestbed(t *testing.T) {


### PR DESCRIPTION
- in support of coauthors efforts (#144, #121, #81) per request from @lamalex 
- also creates the /tmp/mob/notgit subdir
- includes a simple test case for the testbed itself
- includes the code allowing run() to return a string, and a test case for same
