### PR TITLE
update install instructions with go install

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,7 @@ Smooth [git handover](https://www.remotemobprogramming.org/#git-handover) with '
 
 ## How to install
 
-Via `go install`:
-```
-# works for any environment with go tooling and a defined GOPATH
-go get -u github.com/remotemobprogramming/mob
-go install github.com/remotemobprogramming/mob
-```
-
-Via an install script:
+The preferred way to install mob is as a binary via the provided install script:
 ```
 # works for macOS, linux, and even on windows in git bash
 curl -sL install.mob.sh | sh
@@ -74,6 +67,19 @@ On Arch Linux via yay:
 
 ```bash
 yay -S mobsh-bin
+```
+
+### Using go tools
+
+When you already have a working go environment with a defined GOPATH you can install latest via `go install`:
+```
+go get github.com/remotemobprogramming/mob
+go install github.com/remotemobprogramming/mob
+```
+
+If run into issues with that version and are using go >= 1.16 you can revert to a previous version by using the package@version syntax:
+```
+go install github.com/remotemobprogramming/mob@v1.2.0
 ```
 
 ## How to use

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Smooth [git handover](https://www.remotemobprogramming.org/#git-handover) with '
 
 ## How to install
 
+Via `go install`:
+```
+# works for any environment with go tooling and a defined GOPATH
+go get -u github.com/remotemobprogramming/mob
+go install github.com/remotemobprogramming/mob
+```
+
+Via an install script:
 ```
 # works for macOS, linux, and even on windows in git bash
 curl -sL install.mob.sh | sh

--- a/README.md
+++ b/README.md
@@ -72,12 +72,19 @@ yay -S mobsh-bin
 ### Using go tools
 
 When you already have a working go environment with a defined GOPATH you can install latest via `go install`:
+
+With go &lt; 1.16
 ```
 go get github.com/remotemobprogramming/mob
 go install github.com/remotemobprogramming/mob
 ```
 
-If run into issues with that version and are using go >= 1.16 you can revert to a previous version by using the package@version syntax:
+go 1.16 introduced support for package@version syntax so you can install directly with:
+```
+go install github.com/remotemobprogramming/mob@latest
+```
+
+or pick a specific version:
 ```
 go install github.com/remotemobprogramming/mob@v1.2.0
 ```


### PR DESCRIPTION
I tried this method and it worked well. Seems more idomatic these days for go-based tools.

The `go install` command does a `go build` (figuring out binary name based on folder name and/or package name) and then moves the binary to the bin folder under your `GOPATH`