### PR TITLE
GH-160 fix createtestbed to match tests

### DIFF
--- a/create-testbed
+++ b/create-testbed
@@ -30,7 +30,7 @@ echo ""
 echo "Creating remote repository ${remotedir}"
 rm -rf "${remotedir}"
 mkdir -p "${remotedir}"
-(cd "${remotedir}" && git --bare init)
+(cd "${remotedir}" && git --bare init --initial-branch=master)
 
 # create first local repo
 createrepo "${localdir}"
@@ -38,7 +38,7 @@ createrepo "${localdir}"
 # populate an initial import
 echo "Populating and pushing"
 (cd "${localdir}" && echo "test" >test.txt && mkdir subdir && echo "subdir" >subdir/subdir.txt)
-(cd "${localdir}" && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
+(cd "${localdir}" && git checkout -b master && git add . && git commit -m "initial import" && git push --set-upstream --all origin)
 
 # create more local repos
 for name in localother alice bob


### PR DESCRIPTION
This commit ensures the createtestbed creates and
checks out the specific branch expected by the
tests, even when the local git client is configured
with a different default.

Previously the createtestbed script not being
explicit about branch names when creating it's first
commit so would inherit the default branch name
which you have configured in your local git client

If, for example, you have configured your local git
client to use 'main' as the default branch name, then
the createtestbed script was creating repos under
/tmp/mob/... which had 'main' as the default branch
name

The tests, however, are still hard-coded to a legacy
assumption about the default branch name and so
could fail like this:

    SET WORKING DIR TO /tmp/mob/local
    ======================
    mob_test.go:981:

            exp: "on branch master"

            got: "on branch main"

    --- FAIL: TestNotAGitRepoMessage (0.56s)
    FAIL
    FAIL    github.com/remotemobprogramming/mob     25.747s
    FAIL

This commit explicitly sets the branch name both
when initializing the bare 'remote' repo and before
creating the first commit in the 'local' repo; this allows
the tests to pass without changing the code's current
legacy assumptions about default branch name.