### PR TITLE
snap update

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ On Ubuntu via [snap](https://snapcraft.io/mob-sh):
 ```bash
 sudo snap install mob-sh
 sudo snap connect mob-sh:ssh-keys
-sudo snap connect mob-sh:gitconfig
-sudo snap alias mob-sh mob
 ```
 
 

--- a/snap/local/mob-launcher
+++ b/snap/local/mob-launcher
@@ -1,2 +1,11 @@
 #!/bin/sh
-HOME=$(getent passwd $(id -u) | cut -d ':' -f 6); mob "$@"
+if snapctl is-connected ssh-keys; then
+  HOME=$(getent passwd $(id -u) | cut -d ':' -f 6); mob "$@"
+else
+  echo " 👉 mob-sh has no access to ssh-keys, please run"
+  echo ""
+  echo "   sudo snap connect mob-sh:ssh-keys"
+  echo ""
+  exit 1
+fi
+

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mob-sh
 base: core18
-version: '1.5.0'
+version: '1.6.0'
 summary: Fast git handover with mob
 description: |
   Smooth git handover with 'mob' for remote mob or pair programming.


### PR DESCRIPTION
- automatic connection of gitconfig has been granted, removed manual connection from README
- automatic alias to mob has been granted, removed manual alias creation from README
- automatic connection to ssh-keys has been rejected, manual connection is checked in mob-launcher
- bump version to 1.6.0