### PR TITLE
Branch value

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -73,6 +73,10 @@ func (branch Branch) String() string {
 	return branch.Name
 }
 
+func (branch Branch) Is(branchName string) bool {
+	return branch.Name == branchName
+}
+
 func main() {
 	parseDebug(os.Args)
 
@@ -360,7 +364,7 @@ func branch(configuration Configuration) {
 }
 
 func determineBranches(currentBranch Branch, localBranches []string, configuration Configuration) (baseBranch Branch, wipBranch Branch) {
-	if currentBranch.Name == "mob-session" || (currentBranch.Name == "master" && !configuration.customWipBranchQualifierConfigured()) {
+	if currentBranch.Is("mob-session") || (currentBranch.Is("master") && !configuration.customWipBranchQualifierConfigured()) {
 		// DEPRECATED
 		baseBranch = newBranch("master")
 		wipBranch = newBranch("mob-session")

--- a/mob.go
+++ b/mob.go
@@ -59,6 +59,14 @@ func (c Configuration) remoteBranch(branch string) string {
 	return c.RemoteName + "/" + branch
 }
 
+func (c Configuration) addWipPrefix(branch string) string {
+	return c.WipBranchPrefix + branch
+}
+
+func (c Configuration) removeWipPrefix(branch string) string { //TODO improve, add tests
+	return branch[len(c.WipBranchPrefix):]
+}
+
 type Branch struct {
 	Name string
 }
@@ -75,6 +83,10 @@ func (branch Branch) String() string {
 
 func (branch Branch) Is(branchName string) bool {
 	return branch.Name == branchName
+}
+
+func (branch Branch) IsWipBranch(configuration Configuration) bool {
+	return strings.Index(branch.Name, configuration.WipBranchPrefix) == 0
 }
 
 func main() {
@@ -368,7 +380,7 @@ func determineBranches(currentBranch Branch, localBranches []string, configurati
 		// DEPRECATED
 		baseBranch = newBranch("master")
 		wipBranch = newBranch("mob-session")
-	} else if configuration.isWipBranch(currentBranch.Name) {
+	} else if currentBranch.IsWipBranch(configuration) {
 		baseBranch = newBranch(removeWipQualifier(configuration.removeWipPrefix(currentBranch.Name), localBranches, configuration))
 		wipBranch = currentBranch
 	} else {
@@ -418,18 +430,6 @@ func removeSuffix(branch string, suffix string) string {
 
 func removeFromSeparator(branch string, separator string) string {
 	return branch[:strings.LastIndex(branch, separator)]
-}
-
-func (c Configuration) isWipBranch(branch string) bool {
-	return strings.Index(branch, c.WipBranchPrefix) == 0
-}
-
-func (c Configuration) addWipPrefix(branch string) string {
-	return c.WipBranchPrefix + branch
-}
-
-func (c Configuration) removeWipPrefix(branch string) string { //TODO improve, add tests
-	return branch[len(c.WipBranchPrefix):]
 }
 
 func addSuffix(branch string, suffix string) string {

--- a/mob.go
+++ b/mob.go
@@ -712,7 +712,7 @@ func startJoinMobSession(configuration Configuration) {
 
 	sayInfo("joining existing mob session from " + currentWipBranch.remote(configuration).String())
 	git("checkout", "-B", currentWipBranch.Name, currentWipBranch.remote(configuration).Name)
-	git("branch", "--set-upstream-to="+configuration.RemoteName+"/"+currentWipBranch.String(), currentWipBranch.String())
+	git("branch", "--set-upstream-to="+currentWipBranch.remote(configuration).Name, currentWipBranch.Name)
 }
 
 func startNewMobSession(configuration Configuration) {
@@ -720,7 +720,7 @@ func startNewMobSession(configuration Configuration) {
 
 	sayInfo("starting new mob session from " + currentBaseBranch.remote(configuration).String())
 	git("checkout", "-B", currentWipBranch.Name, currentBaseBranch.remote(configuration).Name)
-	git("push", "--no-verify", "--set-upstream", configuration.RemoteName, currentWipBranch.String())
+	git("push", "--no-verify", "--set-upstream", configuration.RemoteName, currentWipBranch.Name)
 }
 
 func getUntrackedFiles() string {

--- a/mob_test.go
+++ b/mob_test.go
@@ -109,37 +109,37 @@ func TestRemoveWipBranchQualifier(t *testing.T) {
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = "green"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "master", removeWipQualifier("master-green", []string{}, configuration))
+	equals(t, "master", newBranch("master-green").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = "test-branch"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "master", removeWipQualifier("master-test-branch", []string{}, configuration))
+	equals(t, "master", newBranch("master-test-branch").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = "branch"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "master-test", removeWipQualifier("master-test-branch", []string{}, configuration))
+	equals(t, "master-test", newBranch("master-test-branch").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = "branch"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "master-test", removeWipQualifier("master-test-branch", []string{"master-test"}, configuration))
+	equals(t, "master-test", newBranch("master-test-branch").removeWipQualifier([]string{"master-test"}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "/-/"
 	configuration.WipBranchQualifier = "branch-qualifier"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "main", removeWipQualifier("main/-/branch-qualifier", []string{}, configuration))
+	equals(t, "main", newBranch("main/-/branch-qualifier").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = "branchqualifier"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "main/branchqualifier", removeWipQualifier("main/branchqualifier", []string{}, configuration))
+	equals(t, "main/branchqualifier", newBranch("main/branchqualifier").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = ""
 	configuration.WipBranchQualifier = "branchqualifier"
 	configuration.WipBranchQualifierSet = true
-	equals(t, "main", removeWipQualifier("mainbranchqualifier", []string{}, configuration))
+	equals(t, "main", newBranch("mainbranchqualifier").removeWipQualifier([]string{}, configuration).Name)
 }
 
 func TestRemoveWipBranchQualifierWithoutBranchQualifierSet(t *testing.T) {
@@ -148,12 +148,12 @@ func TestRemoveWipBranchQualifierWithoutBranchQualifierSet(t *testing.T) {
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = ""
 	configuration.WipBranchQualifierSet = false
-	equals(t, "main", removeWipQualifier("main", []string{}, configuration))
+	equals(t, "main", newBranch("main").removeWipQualifier([]string{}, configuration).Name)
 
 	configuration.WipBranchQualifierSeparator = "-"
 	configuration.WipBranchQualifier = ""
 	configuration.WipBranchQualifierSet = false
-	equals(t, "master", removeWipQualifier("master-test-branch", []string{}, configuration))
+	equals(t, "master", newBranch("master-test-branch").removeWipQualifier([]string{}, configuration).Name)
 }
 
 func TestMobRemoteNameEnvironmentVariable(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -91,8 +91,8 @@ func assertDetermineBranches(t *testing.T, branch string, qualifier string, bran
 	configuration := getDefaultConfiguration()
 	configuration.WipBranchQualifier = qualifier
 	baseBranch, wipBranch := determineBranches(branch, branches, configuration)
-	equals(t, expectedBase, baseBranch)
-	equals(t, expectedWip, wipBranch)
+	equals(t, newBranch(expectedBase), baseBranch)
+	equals(t, newBranch(expectedWip), wipBranch)
 }
 
 func TestRemoveWipPrefix(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -98,9 +98,9 @@ func assertDetermineBranches(t *testing.T, branch string, qualifier string, bran
 func TestRemoveWipPrefix(t *testing.T) {
 	configuration := getDefaultConfiguration()
 	configuration.WipBranchPrefix = "mob/"
-	equals(t, "master-green", configuration.removeWipPrefix("mob/master-green"))
-	equals(t, "master-green-blue", configuration.removeWipPrefix("mob/master-green-blue"))
-	equals(t, "main-branch", configuration.removeWipPrefix("mob/main-branch"))
+	equals(t, "master-green", newBranch("mob/master-green").removeWipPrefix(configuration).Name)
+	equals(t, "master-green-blue", newBranch("mob/master-green-blue").removeWipPrefix(configuration).Name)
+	equals(t, "main-branch", newBranch("mob/main-branch").removeWipPrefix(configuration).Name)
 }
 
 func TestRemoveWipBranchQualifier(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1052,7 +1052,7 @@ func assertOutputNotContains(t *testing.T, output *string, notContains string) {
 
 func assertMobSessionBranches(t *testing.T, configuration Configuration, branch string) {
 	if !hasRemoteBranch(branch, configuration) {
-		failWithFailure(t, configuration.remoteBranch(branch), "none")
+		failWithFailure(t, newBranch(branch).remote(configuration).Name, "none")
 	}
 	if !hasLocalBranch(branch) {
 		failWithFailure(t, branch, "none")
@@ -1061,7 +1061,7 @@ func assertMobSessionBranches(t *testing.T, configuration Configuration, branch 
 
 func assertNoMobSessionBranches(t *testing.T, configuration Configuration, branch string) {
 	if hasRemoteBranch(branch, configuration) {
-		failWithFailure(t, "none", configuration.remoteBranch(branch))
+		failWithFailure(t, "none", newBranch(branch).remote(configuration).Name)
 	}
 	if hasLocalBranch(branch) {
 		failWithFailure(t, "none", branch)

--- a/mob_test.go
+++ b/mob_test.go
@@ -90,7 +90,7 @@ func TestDetermineBranches(t *testing.T) {
 func assertDetermineBranches(t *testing.T, branch string, qualifier string, branches []string, expectedBase string, expectedWip string) {
 	configuration := getDefaultConfiguration()
 	configuration.WipBranchQualifier = qualifier
-	baseBranch, wipBranch := determineBranches(branch, branches, configuration)
+	baseBranch, wipBranch := determineBranches(newBranch(branch), branches, configuration)
 	equals(t, newBranch(expectedBase), baseBranch)
 	equals(t, newBranch(expectedWip), wipBranch)
 }
@@ -1032,8 +1032,8 @@ func createFile(t *testing.T, filename string, content string) (pathToFile strin
 
 func assertOnBranch(t *testing.T, branch string) {
 	currentBranch := gitCurrentBranch()
-	if currentBranch != branch {
-		failWithFailure(t, "on branch "+branch, "on branch "+currentBranch)
+	if currentBranch.Name != branch {
+		failWithFailure(t, "on branch "+branch, "on branch "+currentBranch.String())
 	}
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -1051,7 +1051,7 @@ func assertOutputNotContains(t *testing.T, output *string, notContains string) {
 }
 
 func assertMobSessionBranches(t *testing.T, configuration Configuration, branch string) {
-	if !hasRemoteBranch(branch, configuration) {
+	if !newBranch(branch).hasRemoteBranch(configuration) {
 		failWithFailure(t, newBranch(branch).remote(configuration).Name, "none")
 	}
 	if !hasLocalBranch(branch) {
@@ -1060,7 +1060,7 @@ func assertMobSessionBranches(t *testing.T, configuration Configuration, branch 
 }
 
 func assertNoMobSessionBranches(t *testing.T, configuration Configuration, branch string) {
-	if hasRemoteBranch(branch, configuration) {
+	if newBranch(branch).hasRemoteBranch(configuration) {
 		failWithFailure(t, "none", newBranch(branch).remote(configuration).Name)
 	}
 	if hasLocalBranch(branch) {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -26,7 +26,7 @@ last commit must be a manual commit`)
 	}
 
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-	mergeBase := silentgit("merge-base", currentWipBranch, currentBaseBranch)
+	mergeBase := silentgit("merge-base", currentWipBranch.String(), currentBaseBranch.String())
 
 	originalGitEditor, originalGitSequenceEditor := getEnvGitEditor()
 	setEnvGitEditor(
@@ -35,9 +35,9 @@ last commit must be a manual commit`)
 	)
 	silentgit("rebase", "-i", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
-	sayInfo("the history of your " + currentWipBranch + " branch has been rewritten to combine all wip commits with their following manual commits:")
+	sayInfo("the history of your " + currentWipBranch.String() + " branch has been rewritten to combine all wip commits with their following manual commits:")
 	sayEmptyLine()
-	sayLastCommitsWithMessage(currentBaseBranch, currentWipBranch)
+	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
 	sayEmptyLine()
 	sayTodo("to finally put the changes into the base branch preserving the resulting commits, call:", "mob done --no-squash")
 }
@@ -127,7 +127,7 @@ func endsWithWipCommit(configuration Configuration) bool {
 
 func commitsOnCurrentBranch(configuration Configuration) []string {
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-	commitsBaseWipBranch := currentBaseBranch + ".." + currentWipBranch
+	commitsBaseWipBranch := currentBaseBranch.String() + ".." + currentWipBranch.String()
 	log := silentgit("--no-pager", "log", commitsBaseWipBranch, "--pretty=format:%s")
 	lines := strings.Split(log, "\n")
 	return lines

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -64,7 +64,7 @@ func TestSquashWipCommits_failsOnFinalWipCommit(t *testing.T) {
 
 	squashWip(configuration)
 
-	assertCommitLogContainsMessage(t, gitCurrentBranch(), configuration.WipCommitMessage)
+	assertCommitLogContainsMessage(t, gitCurrentBranch().Name, configuration.WipCommitMessage)
 	assertOutputContains(t, output, "failed to squash wip commits")
 }
 


### PR DESCRIPTION
I introduced a Value Object `Branch`.
See where this is going?
Some of the behavior of `Configuration` moved to `Branch` where it is more appropriate.
`Branch` could even accumulate more behavior such as `checkout` and many more.
While it's tempting to move some git wrapper functions into `Branch`, I think this should only be a temporary solution.
At one point we probably want a git interface that abstracts away all git functionality.
Once we have that, git should be passed as an argument to branch.
E.g.
```
git = newGitCliWrapper()
newBranch("mob-session").checkout(git)
```

I see many advantages in this design.

What do you think?