### PR TITLE
Update the minimum required version of Go to 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ MOB_NEXT_STAY=true mob next
 cd $PROJECT_ROOT
 
 git version # >= 2.17
-go version # >= 1.14
+go version # >= 1.15
 
 go build # builds 'mob'
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/remotemobprogramming/mob
 
-go 1.14
+go 1.15


### PR DESCRIPTION
As discussed in issue #200 the test suite fails using Go 1.14. This PR copies #152 and updates the minimum required version to 1.15.

<br>

**Test Plan:**

The build works locally and in the Actions. See https://github.com/seanpoulter/mob/actions/runs/1392883203.

![image](https://user-images.githubusercontent.com/2585460/139178750-725e429d-d453-4357-808a-565c4646261b.png)

<br>

PS: Congrats on the mention in Technology Radar. 🥳 