### PR TITLE
Improve message when there is nothing to commit

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -980,7 +980,11 @@ func done(configuration Configuration) {
 		git("branch", "-D", currentWipBranch.Name)
 		git("push", "--no-verify", configuration.RemoteName, "--delete", currentWipBranch.Name)
 
-		sayInfoIndented(getCachedChanges())
+		cachedChanges := getCachedChanges()
+		hasCachedChanges := len(cachedChanges) > 0
+		if hasCachedChanges {
+			sayInfoIndented(cachedChanges)
+		}
 		err := appendCoauthorsToSquashMsg(gitDir())
 		if err != nil {
 			sayError(err.Error())

--- a/mob.go
+++ b/mob.go
@@ -986,7 +986,11 @@ func done(configuration Configuration) {
 			sayError(err.Error())
 		}
 		if configuration.MobDoneSquash {
-			sayTodo("To finish, use", "git commit")
+			if isNothingToCommit() {
+				sayInfo("nothing was done, so nothing to commit")
+			} else {
+				sayTodo("To finish, use", "git commit")
+			}
 		}
 
 	} else {

--- a/mob_test.go
+++ b/mob_test.go
@@ -918,6 +918,17 @@ func TestDoneMerge(t *testing.T) {
 	assertOutputContains(t, output, "  git commit")
 }
 
+func TestDoneSquashNoChanges(t *testing.T) {
+	output, configuration := setup(t)
+	setWorkingDir(tempDir + "/local")
+	checkoutBranch("feature-something")
+
+	start(configuration)
+	done(configuration)
+
+	assertOutputContains(t, output, "nothing to commit")
+}
+
 func TestStartAndNextInSubdir(t *testing.T) {
 	_, configuration := setup(t)
 


### PR DESCRIPTION
This PR implements the feature requested in #197:

> Given there are no squashed changes made on a branch  
> When a user runs `mob done`  
> Then it should show an info message

<br>

**Demo:**

https://user-images.githubusercontent.com/2585460/139372391-a7063a7f-1d2d-4d04-a43f-b590d8272616.mp4

<br>

**Test Plan:**

It has been manually tested and unit tested.
