### PR TITLE
chore: Switch to the official actions/setup-go GitHub Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,9 @@ jobs:
     - name: Show git version
       run: git version
     - uses: actions/checkout@v2
-    - name: Use Go 1.16 to test
-      uses: cedrickring/golang-action/go1.16@1.7.0
+    - name: Use Go 1.16.x
+      uses: actions/setup-go@v2
       with:
-        args: go test
+        go-version: '~1.16.0'
+    - name: Test
+      run: go test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,16 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Use Go 1.16 to test
-        uses: cedrickring/golang-action/go1.16@1.7.0
+      - name: Use Go 1.16.x
+        uses: actions/setup-go@v2
         with:
-          args: go test
+          go-version: '~1.16.0'
+      - name: Test
+        run: go test
         env:
           GOOS: linux # the tests will only run if the os matches the os of the system of run-on
-      - name: Use Go 1.16 to build
-        uses: cedrickring/golang-action/go1.16@1.7.0
-        with:
-          args: go build -o mob${{ matrix.os == 'windows' && '.exe' || '' }}
+      - name: Build
+        run: go build -o mob${{ matrix.os == 'windows' && '.exe' || '' }}
         env:
           GOOS: ${{ matrix.os }}
       - name: Create release artifacts using .github/build


### PR DESCRIPTION
The `cedrickring/golang-action` GitHub Action has been deprecated and will not be maintained to support new versions of Go beyond v1.16. This PR switches to the official `actions/setup-go` action.

**Notes**:

- `cedrickring/golang-action` uses the latest patch version (for example, 1.16.x). To reproduce this behaviour we need the `~` in `~1.16.0`.
- The new action makes it even easier to set up a build matrix to get many versions of Go

This PR closes #205.