### PR TITLE
docs: Update the separator from `/` to `-` to match current behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Basic Commands:
 Basic Commands(Options):
   start [<minutes>]                      Start a <minutes> timer
     [--include-uncommitted-changes|-i]   Move uncommitted changes to wip branch
-    [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>/<branch-postfix>'
+    [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>-<branch-postfix>'
   next
     [--stay|-s]                          Stay on wip branch (default)
     [--return-to-base-branch|-r]         Return to base branch
@@ -153,7 +153,7 @@ Basic Commands(Options):
     [--no-squash]                        Do not squash commits from wip branch
     [--squash]                           Squash commits from wip branch
   reset
-    [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>/<branch-postfix>'
+    [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>-<branch-postfix>'
 
 Experimental Commands:
   squash-wip                             Combines wip commits in wip branch with subsequent manual commits to leave only manual commits.


### PR DESCRIPTION
This is a quick edit to the docs. The separator changed in v1.0.0 from `/` to `-`. 