### PR TITLE
README: remove obsolete reference to arch/aur

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,6 @@ Example installation using AUR helper `yay`:
 
 ```bash
 yay -S mobsh-bin
-
-# OR
-yay -S mobsh
 ```
 
 ### Linux Timer


### PR DESCRIPTION
Since there is no more package `mobsh` (we only provide `mobsh-bin`) we should probably also remove the reference from the README.