### PR TITLE
No squash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 2.2.0
 - When mob encounters unpushed commits in the base branch, the tool now provides help for the user to fix this immediately.
 - Improves console output when using `mob break 5` in combination with https://timer.mob.sh
+- Gives the user the chance to name their final commit after `mob done --no-squash`
 
 # 2.1.0
 - When having set `MOB_TIMER_ROOM` the local timer keeps on working. To disable the local timer altogether, please disable it via `export MOB_TIMER_LOCAL=false`.

--- a/mob.go
+++ b/mob.go
@@ -1016,10 +1016,10 @@ func done(configuration Configuration) {
 			sayError(err.Error())
 		}
 
-		if isNothingToCommit() {
-			sayInfo("nothing was done, so nothing to commit")
-		} else {
+		if hasUncommittedChanges() {
 			sayTodo("To finish, use", "git commit")
+		} else if configuration.MobDoneSquash {
+			sayInfo("nothing was done, so nothing to commit")
 		}
 
 	} else {

--- a/mob.go
+++ b/mob.go
@@ -985,7 +985,8 @@ func done(configuration Configuration) {
 	baseBranch, wipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
 
 	if wipBranch.hasRemoteBranch(configuration) {
-		if hasUncommittedChanges() {
+		uncommittedChanges := hasUncommittedChanges()
+		if uncommittedChanges {
 			makeWipCommit(configuration)
 		}
 		git("push", "--no-verify", configuration.RemoteName, wipBranch.Name)
@@ -998,6 +999,11 @@ func done(configuration Configuration) {
 		}
 
 		git("branch", "-D", wipBranch.Name)
+
+		if uncommittedChanges && !configuration.MobDoneSquash { // give the user the chance to name their final commit
+			silentgit("reset", "--soft", "HEAD^")
+		}
+
 		git("push", "--no-verify", configuration.RemoteName, "--delete", wipBranch.Name)
 
 		cachedChanges := getCachedChanges()

--- a/mob.go
+++ b/mob.go
@@ -1001,7 +1001,7 @@ func done(configuration Configuration) {
 		git("branch", "-D", wipBranch.Name)
 
 		if uncommittedChanges && !configuration.MobDoneSquash { // give the user the chance to name their final commit
-			silentgit("reset", "--soft", "HEAD^")
+			git("reset", "--soft", "HEAD^")
 		}
 
 		git("push", "--no-verify", configuration.RemoteName, "--delete", wipBranch.Name)

--- a/mob.go
+++ b/mob.go
@@ -1015,12 +1015,11 @@ func done(configuration Configuration) {
 		if err != nil {
 			sayError(err.Error())
 		}
-		if configuration.MobDoneSquash {
-			if isNothingToCommit() {
-				sayInfo("nothing was done, so nothing to commit")
-			} else {
-				sayTodo("To finish, use", "git commit")
-			}
+
+		if isNothingToCommit() {
+			sayInfo("nothing was done, so nothing to commit")
+		} else {
+			sayTodo("To finish, use", "git commit")
 		}
 
 	} else {

--- a/mob_test.go
+++ b/mob_test.go
@@ -708,6 +708,41 @@ func TestStartDoneSquashTheOneManualCommit(t *testing.T) {
 	assertNoMobSessionBranches(t, configuration, "mob-session")
 }
 
+func TestStartDoneWithUncommittedChanges(t *testing.T) {
+	_, configuration := setup(t)
+
+	start(configuration) // should be 1 commit on mob-session so far
+	createFile(t, "example.txt", "content")
+
+	done(configuration)
+
+	assertOnBranch(t, "master")
+	assertGitStatus(t, GitStatus{
+		"example.txt": "A",
+	})
+	assertCommitsOnBranch(t, 1, "master")
+	assertCommitsOnBranch(t, 1, "origin/master")
+	assertNoMobSessionBranches(t, configuration, "mob-session")
+}
+
+func TestStartDoneNoSquashWithUncommittedChanges(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.MobDoneSquash = false // default is true
+
+	start(configuration) // should be 1 commit on mob-session so far
+	createFile(t, "example.txt", "content")
+
+	done(configuration) // without squash (configuration)
+
+	assertOnBranch(t, "master")
+	assertGitStatus(t, GitStatus{
+		"example.txt": "A",
+	})
+	assertCommitsOnBranch(t, 1, "master")
+	assertCommitsOnBranch(t, 1, "origin/master")
+	assertNoMobSessionBranches(t, configuration, "mob-session")
+}
+
 func TestStartDoneFeatureBranch(t *testing.T) {
 	_, configuration := setup(t)
 	git("checkout", "-b", "feature1")


### PR DESCRIPTION
When the user has uncommitted changes and runs `mob done --no-squash`, the changes get commited in a wip commit, but this wip commit gets reset softly after the merge, so the user gets the chance to commit the changes manually with a proper message. 

Tackles this Issue: https://github.com/remotemobprogramming/mob/issues/219 