### PR TITLE
Squash wip improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.6.0
 - **NEW** Allow keeping manual commits while squashing all wip commits by finishing a mob-session with `mob done --squash-wip`.
-- `mob squash-wip` now also combines consecutive wip commits if they are not followed by a manual commit. This command is now deprecated, as it is integrated into `mob done --squash-wip`.  
+- Removed experimental command `mob squash-wip` in favor of new `mob done --squash-wip`.  
 
 # 2.5.0
 - Enable git hooks with `MOB_GIT_HOOKS_ENABLED=true`. By default, this option is false and no git hooks such as `pre-commit` or `pre-push` are triggered via mob itself.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.6.0
+- **NEW** Allow keeping manual commits while squashing all wip commits by finishing a mob-session with `mob done --squash-wip`.
+- `mob squash-wip` now also combines consecutive wip commits if they are not followed by a manual commit. This command is now deprecated, as it is integrated into `mob done --squash-wip`.  
+
 # 2.5.0
 - Enable git hooks with `MOB_GIT_HOOKS_ENABLED=true`. By default, this option is false and no git hooks such as `pre-commit` or `pre-push` are triggered via mob itself.
 

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Basic Commands(Options):
   done
     [--no-squash]                        Do not squash commits from wip branch
     [--squash]                           Squash commits from wip branch
+    [--squash-wip]                       Squash wip commits from wip branch, maintaining manual commits
   reset
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>-<branch-postfix>'
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Basic Commands(Options):
 
 Experimental Commands:
   squash-wip                             Combines wip commits in wip branch with subsequent manual commits to leave only manual commits.
-                                         ! Works only if all wip commits have the same wip commit message !
+                                         !Deprecated! As of version 2.6.0 this command is obsolete as the behaviour is added to 'done --squash-wip' which is more convenient.
+                                         
     [--git-editor]                       Not intended for manual use. Used as a non-interactive editor (GIT_EDITOR) for git.
     [--git-sequence-editor]              Not intended for manual use. Used as a non-interactive sequence editor (GIT_SEQUENCE_EDITOR) for git.
 

--- a/README.md
+++ b/README.md
@@ -172,13 +172,6 @@ Basic Commands(Options):
   reset
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>-<branch-postfix>'
 
-Experimental Commands:
-  squash-wip                             Combines wip commits in wip branch with subsequent manual commits to leave only manual commits.
-                                         !Deprecated! As of version 2.6.0 this command is obsolete as the behaviour is added to 'done --squash-wip' which is more convenient.
-                                         
-    [--git-editor]                       Not intended for manual use. Used as a non-interactive editor (GIT_EDITOR) for git.
-    [--git-sequence-editor]              Not intended for manual use. Used as a non-interactive sequence editor (GIT_SEQUENCE_EDITOR) for git.
-
 Timer Commands:
   timer <minutes>    start a <minutes> timer
   start <minutes>    start mob session in wip branch and a <minutes> timer

--- a/coauthors_test.go
+++ b/coauthors_test.go
@@ -9,27 +9,27 @@ func TestStartDoneCoAuthors(t *testing.T) {
 
 	setWorkingDir(tempDir + "/alice")
 	start(configuration)
-	createFile(t, "file3.txt", "owqe")
+	createFile(t, "file3.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "file1.txt", "asdf")
+	createFile(t, "file1.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
 	start(configuration)
-	createFile(t, "file2.txt", "asdf")
+	createFile(t, "file2.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/alice")
 	start(configuration)
-	createFile(t, "file4.txt", "zcvx")
+	createFile(t, "file4.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/bob")
 	start(configuration)
-	createFile(t, "file5.txt", "oiuo")
+	createFile(t, "file5.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/local")

--- a/mob.go
+++ b/mob.go
@@ -667,6 +667,8 @@ func parseArgs(args []string, configuration Configuration) (command string, para
 			newConfiguration.DoneSquash = Squash
 		case "--no-squash":
 			newConfiguration.DoneSquash = NoSquash
+		case "--squash-wip":
+			newConfiguration.DoneSquash = SquashWip
 		default:
 			if i == 1 {
 				command = arg
@@ -1424,6 +1426,7 @@ Basic Commands(Options):
   done
     [--no-squash]                        Do not squash commits from wip branch
     [--squash]                           Squash commits from wip branch
+    [--squash-wip]                       Squash wip commits from wip branch, maintaining manual commits
   reset
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>/<branch-postfix>'
 

--- a/mob.go
+++ b/mob.go
@@ -31,9 +31,21 @@ type DoneSquash string
 
 const (
 	Squash    DoneSquash = "squash"
-	NoSquash  DoneSquash = "no-squash"
-	SquashWip DoneSquash = "squash-wip"
+	NoSquash             = "no-squash"
+	SquashWip            = "squash-wip"
 )
+
+func doneSquash(value string) DoneSquash {
+	switch value {
+	case "false":
+		fallthrough
+	case NoSquash:
+		return NoSquash
+	case SquashWip:
+		return SquashWip
+	}
+	return Squash
+}
 
 type Configuration struct {
 	CliName                        string     // override with MOB_CLI_NAME
@@ -572,22 +584,15 @@ func setDoneSquashFromEnvVariable(configuration *Configuration, key string) {
 	if !set {
 		return
 	}
+
+	configuration.DoneSquash = doneSquash(value)
+
 	if value == "" {
 		debugInfo("ignoring " + key + "=" + value + " (empty string)")
+		return
 	}
 
-	if value == "true" || value == string(Squash) {
-		configuration.DoneSquash = Squash
-		debugInfo("overriding " + key + "=" + string(Squash))
-	} else if value == "false" || value == string(NoSquash) {
-		configuration.DoneSquash = NoSquash
-		debugInfo("overriding " + key + "=" + string(NoSquash))
-	} else if value == string(SquashWip) {
-		configuration.DoneSquash = SquashWip
-		debugInfo("overriding " + key + "=" + string(SquashWip))
-	} else {
-		sayError("ignoring " + key + "=" + value + " (not a boolean)")
-	}
+	debugInfo("overriding " + key + "=" + string(configuration.DoneSquash))
 }
 
 func removed(key string, message string) {

--- a/mob.go
+++ b/mob.go
@@ -736,8 +736,6 @@ func execute(command string, parameter []string, configuration Configuration) {
 			squashWipGitEditor(parameter[1], configuration)
 		} else if len(parameter) > 1 && parameter[0] == "--git-sequence-editor" {
 			squashWipGitSequenceEditor(parameter[1], configuration)
-		} else {
-			squashWip(configuration)
 		}
 	case "version", "--version", "-v":
 		version()
@@ -1432,12 +1430,6 @@ Basic Commands(Options):
     [--squash-wip]                       Squash wip commits from wip branch, maintaining manual commits
   reset
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>/<branch-postfix>'
-
-Experimental Commands:
-  squash-wip                             Combines wip commits in wip branch with subsequent manual commits to leave only manual commits.
-                                         !Deprecated! As of version 2.6.0 this command is obsolete as the behaviour is added to 'done --squash-wip' which is more convenient.
-    [--git-editor]                       Not intended for manual use. Used as a non-interactive editor (GIT_EDITOR) for git.
-    [--git-sequence-editor]              Not intended for manual use. Used as a non-interactive sequence editor (GIT_SEQUENCE_EDITOR) for git.
 
 Timer Commands:
   timer <minutes>    start a <minutes> timer

--- a/mob.go
+++ b/mob.go
@@ -1435,7 +1435,7 @@ Basic Commands(Options):
 
 Experimental Commands:
   squash-wip                             Combines wip commits in wip branch with subsequent manual commits to leave only manual commits.
-                                         ! Works only if all wip commits have the same wip commit message !
+                                         !Deprecated! As of version 2.6.0 this command is obsolete as the behaviour is added to 'done --squash-wip' which is more convenient.
     [--git-editor]                       Not intended for manual use. Used as a non-interactive editor (GIT_EDITOR) for git.
     [--git-sequence-editor]              Not intended for manual use. Used as a non-interactive sequence editor (GIT_SEQUENCE_EDITOR) for git.
 

--- a/mob.go
+++ b/mob.go
@@ -866,8 +866,8 @@ func getMobTimerRoom(configuration Configuration) string {
 		currentBaseBranch, _ := determineBranches(currentBranch, gitBranches(), configuration)
 
 		if currentBranch.IsWipBranch(configuration) {
-			wipBranchWithouthWipPrefix := currentBranch.removeWipPrefix(configuration).Name
-			currentWipBranchQualifier = removePrefix(removePrefix(wipBranchWithouthWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
+			wipBranchWithoutWipPrefix := currentBranch.removeWipPrefix(configuration).Name
+			currentWipBranchQualifier = removePrefix(removePrefix(wipBranchWithoutWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
 		}
 	}
 

--- a/mob.go
+++ b/mob.go
@@ -37,9 +37,7 @@ const (
 
 func doneSquash(value string) DoneSquash {
 	switch value {
-	case "false":
-		fallthrough
-	case NoSquash:
+	case "false", NoSquash:
 		return NoSquash
 	case SquashWip:
 		return SquashWip

--- a/mob.go
+++ b/mob.go
@@ -30,8 +30,9 @@ var (
 type DoneSquash string
 
 const (
-	Squash   DoneSquash = "--squash"
-	NoSquash DoneSquash = "--no-squash"
+	Squash    DoneSquash = "squash"
+	NoSquash  DoneSquash = "no-squash"
+	SquashWip DoneSquash = "squash-wip"
 )
 
 type Configuration struct {
@@ -575,12 +576,15 @@ func setDoneSquashFromEnvVariable(configuration *Configuration, key string) {
 		debugInfo("ignoring " + key + "=" + value + " (empty string)")
 	}
 
-	if value == "true" {
+	if value == "true" || value == string(Squash) {
 		configuration.DoneSquash = Squash
 		debugInfo("overriding " + key + "=" + string(Squash))
-	} else if value == "false" {
+	} else if value == "false" || value == string(NoSquash) {
 		configuration.DoneSquash = NoSquash
 		debugInfo("overriding " + key + "=" + string(NoSquash))
+	} else if value == string(SquashWip) {
+		configuration.DoneSquash = SquashWip
+		debugInfo("overriding " + key + "=" + string(SquashWip))
 	} else {
 		sayError("ignoring " + key + "=" + value + " (not a boolean)")
 	}
@@ -1214,6 +1218,11 @@ func fetch(configuration Configuration) {
 func done(configuration Configuration) {
 	if !isMobProgramming(configuration) {
 		sayTodo("to start working together, use", configuration.mob("start"))
+		return
+	}
+
+	if configuration.DoneSquash == SquashWip {
+		sayError("`mob done --squash-wip` not yet supported") // TODO
 		return
 	}
 

--- a/mob.go
+++ b/mob.go
@@ -1222,8 +1222,7 @@ func done(configuration Configuration) {
 	}
 
 	if configuration.DoneSquash == SquashWip {
-		sayError("`mob done --squash-wip` not yet supported") // TODO
-		return
+		squashWip(configuration)
 	}
 
 	git("fetch", configuration.RemoteName, "--prune")
@@ -1248,7 +1247,7 @@ func done(configuration Configuration) {
 
 		git("branch", "-D", wipBranch.Name)
 
-		if uncommittedChanges && configuration.DoneSquash == NoSquash { // give the user the chance to name their final commit
+		if uncommittedChanges && configuration.DoneSquash != Squash { // give the user the chance to name their final commit
 			git("reset", "--soft", "HEAD^")
 		}
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -279,7 +279,7 @@ func TestRequireCommitMessage(t *testing.T) {
 	// https://github.com/remotemobprogramming/mob/pull/107#issuecomment-761298861
 	assertOutputContains(t, output, "nothing to commit")
 
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 	// failure message should make sense regardless of whether we
 	// provided commit message via `-m` or MOB_WIP_COMMIT_MESSAGE
@@ -310,7 +310,7 @@ func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
 	start(configuration)
 
 	for i := 0; i < 6; i++ {
-		createFile(t, "test"+strconv.Itoa(i)+".txt", "test")
+		createFile(t, "test"+strconv.Itoa(i)+".txt", "contentIrrelevant")
 		next(configuration)
 	}
 
@@ -565,7 +565,7 @@ func TestReset(t *testing.T) {
 func TestResetCommit(t *testing.T) {
 	_, configuration := setup(t)
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 	assertMobSessionBranches(t, configuration, "mob-session")
 
@@ -578,7 +578,7 @@ func TestResetCommit(t *testing.T) {
 func TestStartUnstagedChanges(t *testing.T) {
 	output, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
-	createFile(t, "test.txt", "content")
+	createFile(t, "test.txt", "contentIrrelevant")
 
 	start(configuration)
 
@@ -590,7 +590,7 @@ func TestStartUnstagedChanges(t *testing.T) {
 func TestStartIncludeUnstagedChanges(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = true
-	createFile(t, "test.txt", "content")
+	createFile(t, "test.txt", "contentIrrelevant")
 
 	start(configuration)
 
@@ -604,7 +604,7 @@ func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
 	Debug = true
 	createDirectory(t, "subdirnew")
 	setWorkingDir(tempDir + "/local/subdirnew")
-	createFile(t, "test.txt", "content")
+	createFile(t, "test.txt", "contentIrrelevant")
 	assertFileExist(t, tempDir+"/local/subdirnew/test.txt")
 
 	start(configuration)
@@ -614,7 +614,7 @@ func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
 
 func TestStartHasUnpushedCommits(t *testing.T) {
 	output, configuration := setup(t)
-	createFileAndCommitIt(t, "test.txt", "content", "unpushed change")
+	createFileAndCommitIt(t, "test.txt", "contentIrrelevant", "unpushed change")
 
 	start(configuration)
 
@@ -634,7 +634,7 @@ func TestBranch(t *testing.T) {
 func TestStartIncludeUntrackedFiles(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = true
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 
 	start(configuration)
 
@@ -644,7 +644,7 @@ func TestStartIncludeUntrackedFiles(t *testing.T) {
 func TestStartUntrackedFiles(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 
 	start(configuration)
 
@@ -654,7 +654,7 @@ func TestStartUntrackedFiles(t *testing.T) {
 func TestStartNextBackToMaster(t *testing.T) {
 	_, configuration := setup(t)
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	assertOnBranch(t, "mob-session")
 
 	next(configuration)
@@ -667,7 +667,7 @@ func TestStartNextStay(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.NextStay = true
 	start(configuration)
-	createFile(t, "file1.txt", "asdf")
+	createFile(t, "file1.txt", "contentIrrelevant")
 	assertOnBranch(t, "mob-session")
 
 	next(configuration)
@@ -753,7 +753,7 @@ func TestStartDonePublishingOneManualCommit(t *testing.T) {
 	assertOnBranch(t, "mob-session")
 	// should be 1 commit on mob-session so far
 
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 	assertCommits(t, 2)
 
 	done(configuration) // without squash (configuration)
@@ -774,7 +774,7 @@ func TestStartDoneSquashTheOneManualCommit(t *testing.T) {
 	assertOnBranch(t, "mob-session")
 	// should be 1 commit on mob-session so far
 
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 	assertCommits(t, 2)
 
 	done(configuration)
@@ -792,7 +792,7 @@ func TestStartDoneWithUncommittedChanges(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration) // should be 1 commit on mob-session so far
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 
 	done(configuration)
 
@@ -828,11 +828,11 @@ func TestStartDoneSquashWipPublishingOneManualCommit(t *testing.T) {
 	configuration.DoneSquash = SquashWip
 
 	start(configuration)
-	createFile(t, "some.txt", "irrelevant")
+	createFile(t, "some.txt", "contentIrrelevant")
 	next(configuration) // this wip commit will be squashed
 
 	start(configuration)
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 
 	done(configuration)
 
@@ -848,7 +848,7 @@ func TestStartDoneSquashWipWithUncommittedChanges(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration) // should be 1 commit on mob-session so far
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 
 	configuration.DoneSquash = SquashWip
 	done(configuration)
@@ -866,11 +866,11 @@ func TestStartDoneSquashWipOneWipCommitAfterManualCommit(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration)
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 	next(configuration)
 
 	start(configuration)
-	createFile(t, "file.txt", "irrelevant") // the user should see these changes staged after done
+	createFile(t, "file.txt", "contentIrrelevant") // the user should see these changes staged after done
 	next(configuration)
 
 	start(configuration)
@@ -890,15 +890,15 @@ func TestStartDoneSquashWipManyWipCommitsAfterManualCommit(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration)
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 	next(configuration)
 
 	start(configuration)
-	createFile(t, "file1.txt", "irrelevant") // the user should see these changes staged after done
+	createFile(t, "file1.txt", "contentIrrelevant") // the user should see these changes staged after done
 	next(configuration)
 
 	start(configuration)
-	createFile(t, "file2.txt", "irrelevant") // the user should see these changes staged after done
+	createFile(t, "file2.txt", "contentIrrelevant") // the user should see these changes staged after done
 	next(configuration)
 
 	start(configuration)
@@ -919,11 +919,11 @@ func TestStartDoneSquashWipOnlyWipCommits(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration)
-	createFile(t, "file1.txt", "irrelevant") // the user should see these changes staged after done
+	createFile(t, "file1.txt", "contentIrrelevant") // the user should see these changes staged after done
 	next(configuration)
 
 	start(configuration)
-	createFile(t, "file2.txt", "irrelevant") // the user should see these changes staged after done
+	createFile(t, "file2.txt", "contentIrrelevant") // the user should see these changes staged after done
 	next(configuration)
 
 	start(configuration)
@@ -943,11 +943,11 @@ func TestStartDoneSquashWipOnlyManualCommits(t *testing.T) {
 	_, configuration := setup(t)
 
 	start(configuration)
-	createFileAndCommitIt(t, "example.txt", "content", "[manual-commit-1] publish this commit to master")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "[manual-commit-1] publish this commit to master")
 	next(configuration)
 
 	start(configuration)
-	createFileAndCommitIt(t, "example2.txt", "content", "[manual-commit-2] publish this commit to master")
+	createFileAndCommitIt(t, "example2.txt", "contentIrrelevant", "[manual-commit-2] publish this commit to master")
 	next(configuration)
 
 	start(configuration)
@@ -1011,11 +1011,11 @@ func TestBothCreateNonemptyCommitWithNext(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "file1.txt", "asdf")
+	createFile(t, "file1.txt", "contentIrrelevant")
 
 	setWorkingDir(tempDir + "/localother")
 	start(configuration)
-	createFile(t, "file2.txt", "asdf")
+	createFile(t, "file2.txt", "contentIrrelevant")
 
 	setWorkingDir(tempDir + "/local")
 	next(configuration)
@@ -1068,7 +1068,7 @@ func TestStartNextPushManualCommits(t *testing.T) {
 	setWorkingDir(tempDir + "/local")
 
 	start(configuration)
-	createFileAndCommitIt(t, "example.txt", "content", "asdf")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "asdf")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
@@ -1087,7 +1087,7 @@ func TestStartNextPushManualCommitsFeatureBranch(t *testing.T) {
 	start(configuration)
 	assertOnBranch(t, "mob/feature1")
 
-	createFileAndCommitIt(t, "example.txt", "content", "asdf")
+	createFileAndCommitIt(t, "example.txt", "contentIrrelevant", "asdf")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
@@ -1102,7 +1102,7 @@ func TestConflictingMobSessions(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
@@ -1116,7 +1116,7 @@ func TestConflictingMobSessions(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "example2.txt", "content")
+	createFile(t, "example2.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
@@ -1129,7 +1129,7 @@ func TestConflictingMobSessionsNextStay(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
@@ -1168,11 +1168,11 @@ func TestDoneMerge(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother")
-	createFileAndCommitIt(t, "example2.txt", "asdf", "asdf")
+	createFileAndCommitIt(t, "example2.txt", "contentIrrelevant", "asdf")
 	git("push")
 
 	setWorkingDir(tempDir + "/local")
@@ -1197,13 +1197,13 @@ func TestStartAndNextInSubdir(t *testing.T) {
 
 	setWorkingDir(tempDir + "/local/subdir")
 	start(configuration)
-	createFile(t, "example.txt", "content")
+	createFile(t, "example.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/localother/subdir")
 	start(configuration)
-	createFile(t, "example2.txt", "content")
-	createFile(t, "../example3.txt", "content")
+	createFile(t, "example2.txt", "contentIrrelevant")
+	createFile(t, "../example3.txt", "contentIrrelevant")
 	next(configuration)
 
 	setWorkingDir(tempDir + "/local/subdir")
@@ -1244,7 +1244,7 @@ func TestEmptyGitStatus(t *testing.T) {
 
 func TestGitStatusWithOneFile(t *testing.T) {
 	setup(t)
-	createFile(t, "hello.txt", "")
+	createFile(t, "hello.txt", "contentIrrelevant")
 
 	status := gitStatus()
 
@@ -1255,8 +1255,8 @@ func TestGitStatusWithOneFile(t *testing.T) {
 
 func TestGitStatusWithManyFiles(t *testing.T) {
 	setup(t)
-	createFile(t, "hello.txt", "")
-	createFile(t, "added.txt", "")
+	createFile(t, "hello.txt", "contentIrrelevant")
+	createFile(t, "added.txt", "contentIrrelevant")
 	git("add", "added.txt")
 
 	status := gitStatus()

--- a/mob_test.go
+++ b/mob_test.go
@@ -178,6 +178,9 @@ func TestMobDoneSquashEnvironmentVariable(t *testing.T) {
 	assertMobDoneSquashValue(t, "true", Squash)
 	assertMobDoneSquashValue(t, "false", NoSquash)
 	assertMobDoneSquashValue(t, "garbage", Squash)
+	assertMobDoneSquashValue(t, "squash", Squash)
+	assertMobDoneSquashValue(t, "no-squash", NoSquash)
+	assertMobDoneSquashValue(t, "squash-wip", SquashWip)
 }
 
 func assertMobDoneSquashValue(t *testing.T, value string, expected DoneSquash) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -51,7 +51,7 @@ func TestParseArgsDoneNoSquash(t *testing.T) {
 
 	equals(t, "done", command)
 	equals(t, "", strings.Join(parameters, ""))
-	equals(t, NoSquash, configuration.DoneSquash)
+	equals(t, NoSquash, string(configuration.DoneSquash))
 }
 
 func TestParseArgsDoneSquash(t *testing.T) {
@@ -185,7 +185,7 @@ func TestMobDoneSquashEnvironmentVariable(t *testing.T) {
 
 func assertMobDoneSquashValue(t *testing.T, value string, expected DoneSquash) {
 	configuration := setEnvVarAndParse("MOB_DONE_SQUASH", value)
-	equals(t, expected, configuration.DoneSquash)
+	equals(t, string(expected), string(configuration.DoneSquash))
 }
 
 func TestBooleanEnvironmentVariables(t *testing.T) {
@@ -366,7 +366,7 @@ func TestReadConfigurationFromFileOverrideEverything(t *testing.T) {
 	equals(t, true, actualConfiguration.StartIncludeUncommittedChanges)
 	equals(t, "green", actualConfiguration.WipBranchQualifier)
 	equals(t, "---", actualConfiguration.WipBranchQualifierSeparator)
-	equals(t, NoSquash, actualConfiguration.DoneSquash)
+	equals(t, NoSquash, string(actualConfiguration.DoneSquash))
 	equals(t, "123", actualConfiguration.Timer)
 	equals(t, "Room_42", actualConfiguration.TimerRoom)
 	equals(t, true, actualConfiguration.TimerRoomUseWipBranchQualifier)

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -24,7 +24,7 @@ func squashWip(configuration Configuration) {
 		mobExecutable()+" squash-wip --git-editor",
 		mobExecutable()+" squash-wip --git-sequence-editor",
 	)
-	sayInfo("rewriting the history of the '" + currentWipBranch.String() + "' branch to squash wip commits but keep manual commits.")
+	sayInfo("rewriting history of '" + currentWipBranch.String() + "': squashing wip commits while keeping manual commits.")
 	git("rebase", "--interactive", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
 	sayInfo("resulting history is:")

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -16,14 +16,6 @@ func squashWip(configuration Configuration) {
 		return
 	}
 
-	if endsWithWipCommit(configuration) {
-		sayError(`failed to squash wip commits
-last commit must be a manual commit`)
-		sayEmptyLine()
-		sayTodo("create a manual commit with a commit message to fix this:", "git commit --allow-empty -m \"your message goes here\"")
-		return
-	}
-
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
 	mergeBase := silentgit("merge-base", currentWipBranch.String(), currentBaseBranch.String())
 
@@ -118,10 +110,6 @@ func commentWipCommits(input string, configuration Configuration) string {
 		}
 	}
 	return strings.Join(result, "\n")
-}
-
-func endsWithWipCommit(configuration Configuration) bool {
-	return configuration.isWipCommitMessage(commitsOnCurrentBranch(configuration)[0])
 }
 
 func commitsOnCurrentBranch(configuration Configuration) []string {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -33,7 +33,8 @@ func squashWip(configuration Configuration) {
 		sayInfo("undoing the final wip commit and staging its changes:")
 		git("reset", "--soft", "HEAD^")
 	}
-	git("push", "--force", "--no-verify")
+
+	git("push", "--force", configuration.gitHooksOption())
 }
 
 func lastCommitIsWipCommit(configuration Configuration) bool {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -26,7 +26,7 @@ func squashWip(configuration Configuration) {
 	)
 	silentgit("rebase", "-i", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
-	silentgit("push", "--force")
+	git("push", "--force")
 
 	sayInfo("the history of your '" + currentWipBranch.String() + "' branch has been rewritten to combine all wip commits with their following manual commits:")
 	sayEmptyLine()

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -24,10 +24,10 @@ func squashWip(configuration Configuration) {
 		mobExecutable()+" squash-wip --git-editor",
 		mobExecutable()+" squash-wip --git-sequence-editor",
 	)
+	sayInfo("rewriting the history of the '" + currentWipBranch.String() + "' branch to squash wip commits but keep manual commits.")
 	git("rebase", "-i", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
-	sayInfo("the history of your '" + currentWipBranch.String() + "' branch has been rewritten to combine all wip commits, if possible with their following manual commits:")
-	sayEmptyLine()
+	sayInfo("resulting history is:")
 	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
 	if lastCommitIsWipCommit(configuration) { // last commit is wip commit
 		sayInfo("undoing the final wip commit and staging its changes:")

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -25,7 +25,7 @@ func squashWip(configuration Configuration) {
 		mobExecutable()+" squash-wip --git-sequence-editor",
 	)
 	sayInfo("rewriting the history of the '" + currentWipBranch.String() + "' branch to squash wip commits but keep manual commits.")
-	git("rebase", "-i", "--keep-empty", mergeBase)
+	git("rebase", "--interactive", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
 	sayInfo("resulting history is:")
 	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -34,7 +34,6 @@ func squashWip(configuration Configuration) {
 		git("reset", "--soft", "HEAD^")
 	}
 	git("push", "--force")
-
 }
 
 func lastCommitIsWipCommit(configuration Configuration) bool {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -126,23 +126,27 @@ func markPostWipCommitsForSquashing(input string, configuration Configuration) s
 	var result []string
 
 	inputLines := strings.Split(input, "\n")
-	for i, line := range inputLines {
-		previousLine := previousLine(inputLines, i)
-
-		if isWipCommitLine(previousLine, configuration) {
-			forthComingLines := inputLines[i:]
-
-			if hasOnlyWipCommits(forthComingLines, configuration) {
-				result = append(result, markFixup(line))
-			} else {
-				result = append(result, markSquash(line))
-			}
-		} else {
-			result = append(result, line) // remains pick
-		}
+	for index := range inputLines {
+		markedLine := markLine(inputLines, index, configuration)
+		result = append(result, markedLine)
 	}
 
 	return strings.Join(result, "\n")
+}
+
+func markLine(inputLines []string, i int, configuration Configuration) string {
+	var resultLine = inputLines[i]
+	previousLine := previousLine(inputLines, i)
+	if isWipCommitLine(previousLine, configuration) {
+		forthComingLines := inputLines[i:]
+
+		if hasOnlyWipCommits(forthComingLines, configuration) {
+			resultLine = markFixup(inputLines[i])
+		} else {
+			resultLine = markSquash(inputLines[i])
+		}
+	}
+	return resultLine
 }
 
 func previousLine(inputLines []string, currentIndex int) string {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -24,15 +24,17 @@ func squashWip(configuration Configuration) {
 		mobExecutable()+" squash-wip --git-editor",
 		mobExecutable()+" squash-wip --git-sequence-editor",
 	)
-	silentgit("rebase", "-i", "--keep-empty", mergeBase)
+	git("rebase", "-i", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
-	sayInfo("the history of your '" + currentWipBranch.String() + "' branch has been rewritten to combine all wip commits with their following manual commits:")
+	sayInfo("the history of your '" + currentWipBranch.String() + "' branch has been rewritten to combine all wip commits, if possible with their following manual commits:")
+	sayEmptyLine()
+	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
 	if lastCommitIsWipCommit(configuration) { // last commit is wip commit
+		sayInfo("undoing the final wip commit and staging its changes:")
 		git("reset", "--soft", "HEAD^")
 	}
 	git("push", "--force")
-	sayEmptyLine()
-	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
+
 }
 
 func lastCommitIsWipCommit(configuration Configuration) bool {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -26,6 +26,8 @@ func squashWip(configuration Configuration) {
 	)
 	silentgit("rebase", "-i", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
+	silentgit("push", "--force")
+
 	sayInfo("the history of your '" + currentWipBranch.String() + "' branch has been rewritten to combine all wip commits with their following manual commits:")
 	sayEmptyLine()
 	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
@@ -110,14 +112,6 @@ func commentWipCommits(input string, configuration Configuration) string {
 		}
 	}
 	return strings.Join(result, "\n")
-}
-
-func commitsOnCurrentBranch(configuration Configuration) []string {
-	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-	commitsBaseWipBranch := currentBaseBranch.String() + ".." + currentWipBranch.String()
-	log := silentgit("--no-pager", "log", commitsBaseWipBranch, "--pretty=format:%s")
-	lines := strings.Split(log, "\n")
-	return lines
 }
 
 func markPostWipCommitsForSquashing(input string, configuration Configuration) string {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -33,7 +33,7 @@ func squashWip(configuration Configuration) {
 		sayInfo("undoing the final wip commit and staging its changes:")
 		git("reset", "--soft", "HEAD^")
 	}
-	git("push", "--force")
+	git("push", "--force", "--no-verify")
 }
 
 func lastCommitIsWipCommit(configuration Configuration) bool {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -125,30 +125,32 @@ func commentWipCommits(input string, configuration Configuration) string {
 func markPostWipCommitsForSquashing(input string, configuration Configuration) string {
 	var result []string
 
-	var shouldChange = false
-	var fixup = true
-
 	inputLines := strings.Split(input, "\n")
 	for i, line := range inputLines {
+		previousLine := previousLine(inputLines, i)
 
-		if shouldChange {
-			if fixup {
+		if isWipCommitLine(previousLine, configuration) {
+			forthComingLines := inputLines[i:]
+
+			if hasOnlyWipCommits(forthComingLines, configuration) {
 				result = append(result, markFixup(line))
 			} else {
 				result = append(result, markSquash(line))
 			}
 		} else {
 			result = append(result, line) // remains pick
-			fixup = true
 		}
-
-		shouldChange = isRebaseWipCommitLine(line, configuration)
-
-		forthComingLines := inputLines[i+1:]
-		fixup = hasOnlyWipCommits(forthComingLines, configuration)
 	}
 
 	return strings.Join(result, "\n")
+}
+
+func previousLine(inputLines []string, currentIndex int) string {
+	var previousLine = ""
+	if currentIndex > 0 {
+		previousLine = inputLines[currentIndex-1]
+	}
+	return previousLine
 }
 
 func hasOnlyWipCommits(forthComingLines []string, configuration Configuration) bool {
@@ -169,7 +171,7 @@ func markFixup(line string) string {
 	return strings.Replace(line, "pick ", "fixup ", 1)
 }
 
-func isRebaseWipCommitLine(line string, configuration Configuration) bool {
+func isWipCommitLine(line string, configuration Configuration) bool {
 	return isPick(line) && isWipCommit(line, configuration)
 }
 

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -15,13 +15,13 @@ func TestSquashWipCommits_acceptance(t *testing.T) {
 
 	// manual commit followed by a wip commit
 	start(configuration)
-	createFileAndCommitIt(t, "file3.txt", "irrelevant", "second manual commit")
-	createFile(t, "file4.txt", "irrelevant")
+	createFileAndCommitIt(t, "file3.txt", "contentIrrelevant", "second manual commit")
+	createFile(t, "file4.txt", "contentIrrelevant")
 	next(configuration)
 
 	// final manual commit
 	start(configuration)
-	createFileAndCommitIt(t, "file5.txt", "irrelevant", "third manual commit")
+	createFileAndCommitIt(t, "file5.txt", "contentIrrelevant", "third manual commit")
 
 	squashWip(configuration)
 
@@ -93,7 +93,7 @@ func TestSquashWipCommits_onlyWipCommits(t *testing.T) {
 func TestSquashWipCommits_resetsEnv(t *testing.T) {
 	_, configuration := setup(t)
 	start(configuration)
-	createFileAndCommitIt(t, "file1.txt", "irrelevant", "new file")
+	createFileAndCommitIt(t, "file1.txt", "contentIrrelevant", "new file")
 	originalGitEditor := "irrelevant"
 	originalGitSequenceEditor := "irrelevant, too"
 	os.Setenv("GIT_EDITOR", originalGitEditor)
@@ -130,11 +130,11 @@ func TestSquashWipCommits_worksWithEmptyCommits(t *testing.T) {
 
 func TestCommitsOnCurrentBranch(t *testing.T) {
 	_, configuration := setup(t)
-	createFileAndCommitIt(t, "file1.txt", "irrelevant", "not on branch")
+	createFileAndCommitIt(t, "file1.txt", "contentIrrelevant", "not on branch")
 	silentgit("push")
 	start(configuration)
-	createFileAndCommitIt(t, "file2.txt", "irrelevant", "on branch")
-	createFile(t, "file3.txt", "irrelevant")
+	createFileAndCommitIt(t, "file2.txt", "contentIrrelevant", "on branch")
+	createFile(t, "file3.txt", "contentIrrelevant")
 	next(configuration)
 	start(configuration)
 
@@ -349,13 +349,13 @@ squash c51a56d manual commit
 
 func wipCommit(t *testing.T, configuration Configuration, filename string) {
 	start(configuration)
-	createFile(t, filename, "irrelevant")
+	createFile(t, filename, "contentIrrelevant")
 	next(configuration)
 }
 
 func manualCommit(t *testing.T, configuration Configuration, filename string, message string) {
 	start(configuration)
-	createFileAndCommitIt(t, filename, "irrelevant", message)
+	createFileAndCommitIt(t, filename, "contentIrrelevant", message)
 	next(configuration)
 }
 

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -11,11 +11,7 @@ import (
 func TestSquashWipCommits_acceptance(t *testing.T) {
 	_, configuration := setup(t)
 	wipCommit(t, configuration, "file1.txt")
-
-	// manual commit
-	start(configuration)
-	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
-	next(configuration)
+	manualCommit(t, configuration, "file2.txt", "first manual commit")
 
 	// manual commit followed by a wip commit
 	start(configuration)
@@ -40,17 +36,11 @@ func TestSquashWipCommits_acceptance(t *testing.T) {
 
 func TestSquashWipCommits_withFinalWipCommit(t *testing.T) {
 	_, configuration := setup(t)
-
 	wipCommit(t, configuration, "file1.txt")
-
-	// manual commit
-	start(configuration)
-	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
-	next(configuration)
-
+	manualCommit(t, configuration, "file2.txt", "first manual commit")
 	wipCommit(t, configuration, "file3.txt")
-
 	start(configuration)
+
 	squashWip(configuration)
 
 	assertOnBranch(t, "mob-session")
@@ -64,19 +54,12 @@ func TestSquashWipCommits_withFinalWipCommit(t *testing.T) {
 
 func TestSquashWipCommits_withManyFinalWipCommits(t *testing.T) {
 	_, configuration := setup(t)
-
 	wipCommit(t, configuration, "file1.txt")
-
-	// manual commit
-	start(configuration)
-	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
-	next(configuration)
-
+	manualCommit(t, configuration, "file2.txt", "first manual commit")
 	wipCommit(t, configuration, "file3.txt")
-
 	wipCommit(t, configuration, "file4.txt")
-
 	start(configuration)
+
 	squashWip(configuration)
 
 	assertOnBranch(t, "mob-session")
@@ -95,6 +78,7 @@ func TestSquashWipCommits_onlyWipCommits(t *testing.T) {
 	wipCommit(t, configuration, "file2.txt")
 	wipCommit(t, configuration, "file3.txt")
 	start(configuration)
+
 	squashWip(configuration)
 
 	assertOnBranch(t, "mob-session")
@@ -366,6 +350,12 @@ squash c51a56d manual commit
 func wipCommit(t *testing.T, configuration Configuration, filename string) {
 	start(configuration)
 	createFile(t, filename, "irrelevant")
+	next(configuration)
+}
+
+func manualCommit(t *testing.T, configuration Configuration, filename string, message string) {
+	start(configuration)
+	createFileAndCommitIt(t, filename, "irrelevant", message)
 	next(configuration)
 }
 

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,7 @@ func TestSquashWipCommits_acceptance(t *testing.T) {
 		"second manual commit",
 		"first manual commit",
 	}, commitsOnCurrentBranch(configuration))
+	equals(t, commitsOnCurrentBranch(configuration), commitsOnRemoteBranch(configuration))
 }
 
 func TestSquashWipCommits_withFinalWipCommit(t *testing.T) {
@@ -271,4 +273,20 @@ squash c51a56d manual commit
 
 	result, _ := ioutil.ReadFile(input)
 	equals(t, expected, string(result))
+}
+
+func commitsOnCurrentBranch(configuration Configuration) []string {
+	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
+	commitsBaseWipBranch := currentBaseBranch.String() + ".." + currentWipBranch.String()
+	log := silentgit("--no-pager", "log", commitsBaseWipBranch, "--pretty=format:%s")
+	lines := strings.Split(log, "\n")
+	return lines
+}
+
+func commitsOnRemoteBranch(configuration Configuration) []string {
+	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
+	commitsBaseWipBranch := currentBaseBranch.String() + ".." + configuration.RemoteName + "/" + currentWipBranch.String()
+	log := silentgit("--no-pager", "log", commitsBaseWipBranch, "--pretty=format:%s")
+	lines := strings.Split(log, "\n")
+	return lines
 }

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -10,24 +10,20 @@ import (
 
 func TestSquashWipCommits_acceptance(t *testing.T) {
 	_, configuration := setup(t)
+	wipCommit(t, configuration, "file1.txt")
 
-	// change without manual commit
-	start(configuration)
-	createFile(t, "file1.txt", "irrelevant")
-	next(configuration)
-
-	// change with a manual commit
+	// manual commit
 	start(configuration)
 	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
 	next(configuration)
 
-	// change with a manual commit followed by an uncommited change
+	// manual commit followed by a wip commit
 	start(configuration)
 	createFileAndCommitIt(t, "file3.txt", "irrelevant", "second manual commit")
 	createFile(t, "file4.txt", "irrelevant")
 	next(configuration)
 
-	// change with a final manual commit
+	// final manual commit
 	start(configuration)
 	createFileAndCommitIt(t, "file5.txt", "irrelevant", "third manual commit")
 
@@ -45,20 +41,14 @@ func TestSquashWipCommits_acceptance(t *testing.T) {
 func TestSquashWipCommits_withFinalWipCommit(t *testing.T) {
 	_, configuration := setup(t)
 
-	// change without manual commit
-	start(configuration)
-	createFile(t, "file1.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file1.txt")
 
-	// change with a manual commit
+	// manual commit
 	start(configuration)
 	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
 	next(configuration)
 
-	// change without manual commit
-	start(configuration)
-	createFile(t, "file3.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file3.txt")
 
 	start(configuration)
 	squashWip(configuration)
@@ -75,25 +65,16 @@ func TestSquashWipCommits_withFinalWipCommit(t *testing.T) {
 func TestSquashWipCommits_withManyFinalWipCommits(t *testing.T) {
 	_, configuration := setup(t)
 
-	// wip commit
-	start(configuration)
-	createFile(t, "file1.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file1.txt")
 
 	// manual commit
 	start(configuration)
 	createFileAndCommitIt(t, "file2.txt", "irrelevant", "first manual commit")
 	next(configuration)
 
-	// wip commit
-	start(configuration)
-	createFile(t, "file3.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file3.txt")
 
-	// wip commit
-	start(configuration)
-	createFile(t, "file4.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file4.txt")
 
 	start(configuration)
 	squashWip(configuration)
@@ -110,19 +91,9 @@ func TestSquashWipCommits_withManyFinalWipCommits(t *testing.T) {
 
 func TestSquashWipCommits_onlyWipCommits(t *testing.T) {
 	_, configuration := setup(t)
-
-	start(configuration)
-	createFile(t, "file1.txt", "irrelevant")
-	next(configuration)
-
-	start(configuration)
-	createFile(t, "file2.txt", "irrelevant")
-	next(configuration)
-
-	start(configuration)
-	createFile(t, "file3.txt", "irrelevant")
-	next(configuration)
-
+	wipCommit(t, configuration, "file1.txt")
+	wipCommit(t, configuration, "file2.txt")
+	wipCommit(t, configuration, "file3.txt")
 	start(configuration)
 	squashWip(configuration)
 
@@ -160,11 +131,7 @@ func TestSquashWipCommits_failsOnMainBranch(t *testing.T) {
 
 func TestSquashWipCommits_worksWithEmptyCommits(t *testing.T) {
 	_, configuration := setup(t)
-
-	// change without manual commit
-	start(configuration)
-	createFile(t, "file1.txt", "irrelevant")
-	next(configuration)
+	wipCommit(t, configuration, "file1.txt")
 
 	start(configuration)
 	silentgit("commit", "--allow-empty", "-m ok")
@@ -394,6 +361,12 @@ squash c51a56d manual commit
 
 	result, _ := ioutil.ReadFile(input)
 	equals(t, expected, string(result))
+}
+
+func wipCommit(t *testing.T, configuration Configuration, filename string) {
+	start(configuration)
+	createFile(t, filename, "irrelevant")
+	next(configuration)
 }
 
 func commitsOnCurrentBranch(configuration Configuration) []string {


### PR DESCRIPTION
Adds new `mob done --squash-wip` option, which does a `mob done` but also runs `squashWip` beforehand.
As a result, when you use `mob done --squash-wip`, you can keep the manual commits you made on the wip branch while getting rid of all the wip commits.

`squashWip` had to be tweaked for this to fixup subsequent wip commits that had no following manual commit. And it also undoes a final wip commit, so that the user is forced to commit those changes manually.

The environment var MOB_DONE_SQUASH is made backward compatible, while the `.mob` config file does not support activating --squash-wip yet.

Questions:

- Should we now already discard the `mob squash-wip` command after all?
- Can you find any corner cases I missed?
