### PR TITLE
adjusted test to assert mob error message instead of git error message

### DIFF
--- a/mob_test.go
+++ b/mob_test.go
@@ -1162,7 +1162,7 @@ func TestDoneMergeConflict(t *testing.T) {
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
 	done(configuration)
-	assertOutputContains(t, output, "Automatic merge failed; fix conflicts and then commit the result.")
+	assertOutputContains(t, output, "To fix this, solve the merge conflict manually, commit, push, and afterwards delete mob-session")
 }
 
 func TestDoneMerge(t *testing.T) {


### PR DESCRIPTION
We had one test, which asserts an error message of git. If your os uses a different language setting the english, this test will fail. I adjusted the test to use the mob specific error message.