### PR TITLE
Issue 240: Use SHA256 instead of MD5 for signing

### DIFF
--- a/.github/build
+++ b/.github/build
@@ -11,4 +11,4 @@ if [ $GOOS == 'windows' ]; then
 fi
 
 tar cvfz ${NAME}.tar.gz "${PROJECT_NAME}${EXT}" LICENSE
-md5sum ${NAME}.tar.gz | cut -d ' ' -f 1 > ${NAME}_checksum.txt
+shasum -a 256 ${NAME}.tar.gz | cut -d ' ' -f 1 > ${NAME}_sha256_checksum.txt


### PR DESCRIPTION
Fixes #240.

Please have a look. I tested this on my fork.
See the names of the files in the test release on my fork: https://github.com/jomora/mob/releases/tag/testsha256. 
(I'll delete the fork after the PR gets approved. So the link won't be valid anymore afterwards.)