### PR TITLE
Uniform exit

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -716,10 +715,8 @@ func execute(command string, parameter []string, configuration Configuration) {
 
 	switch command {
 	case "s", "start":
-		err := start(configuration)
-		if !isMobProgramming(configuration) || err != nil {
-			return
-		}
+		start(configuration)
+
 		if len(parameter) > 0 {
 			timer := parameter[0]
 			startTimer(timer, configuration)
@@ -1072,14 +1069,15 @@ func reset(configuration Configuration) {
 	sayInfo("Branches " + currentWipBranch.String() + " and " + currentWipBranch.remote(configuration).String() + " deleted")
 }
 
-func start(configuration Configuration) error {
+func start(configuration Configuration) {
 	uncommittedChanges := hasUncommittedChanges()
 	if uncommittedChanges && !configuration.StartIncludeUncommittedChanges {
-		sayInfo("cannot start; clean working tree required")
-		sayUnstagedChangesInfo()
+		sayError("cannot start; clean working tree required")
+		sayUnstagedChangesInfo() // TODO perhaps add them to error?
 		sayUntrackedFilesInfo()
 		sayFix("To start, including uncommitted changes, use", configuration.mob("start --include-uncommitted-changes"))
-		return errors.New("cannot start; clean working tree required")
+		exit(1)
+		return
 	}
 
 	git("fetch", configuration.RemoteName, "--prune")
@@ -1088,19 +1086,22 @@ func start(configuration Configuration) error {
 	if !currentBaseBranch.hasRemoteBranch(configuration) {
 		sayError("Remote branch " + currentBaseBranch.remote(configuration).String() + " is missing")
 		sayFix("To set the upstream branch, use", "git push "+configuration.RemoteName+" "+currentBaseBranch.String()+" --set-upstream")
-		return errors.New("remote branch is missing")
+		exit(1)
+		return
 	}
 
 	if currentBaseBranch.hasUnpushedCommits(configuration) {
 		sayError("cannot start; unpushed changes on base branch must be pushed upstream")
 		sayFix("to fix this, push those commits and try again", "git push "+configuration.RemoteName+" "+currentBaseBranch.String())
-		return errors.New("cannot start; unpushed changes on base branch must be pushed upstream")
+		exit(1)
+		return
 	}
 
 	if uncommittedChanges && silentgit("ls-tree", "-r", "HEAD", "--full-name", "--name-only", ".") == "" {
 		sayError("cannot start; current working dir is an uncommitted subdir")
 		sayFix("to fix this, go to the parent directory and try again", "cd ..")
-		return errors.New("cannot start; current working dir is an uncommitted subdir")
+		exit(1)
+		return
 	}
 
 	if uncommittedChanges {
@@ -1130,8 +1131,6 @@ func start(configuration Configuration) error {
 	sayLastCommitsList(currentBaseBranch.String(), currentWipBranch.String())
 
 	openLastModifiedFileIfPresent(configuration)
-
-	return nil // no error
 }
 
 func openLastModifiedFileIfPresent(configuration Configuration) {
@@ -1278,7 +1277,7 @@ func next(configuration Configuration) {
 
 	if !configuration.hasCustomCommitMessage() && configuration.RequireCommitMessage && hasUncommittedChanges() {
 		sayError("commit message required")
-		return
+		exit(1)
 	}
 
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
@@ -1641,6 +1640,7 @@ func silentgit(args ...string) string {
 		sayGitError(commandString, output, err)
 		exit(1)
 	}
+
 	return strings.TrimSpace(output)
 }
 
@@ -1674,9 +1674,9 @@ func git(args ...string) {
 	if err != nil {
 		sayGitError(commandString, output, err)
 		exit(1)
-	} else {
-		sayIndented(commandString)
 	}
+
+	sayIndented(commandString)
 }
 
 func gitCommitHash() string {

--- a/mob_test.go
+++ b/mob_test.go
@@ -257,6 +257,11 @@ func TestNextNotMobProgramming(t *testing.T) {
 
 func TestRequireCommitMessage(t *testing.T) {
 	output, _ := setup(t)
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
 
 	os.Unsetenv("MOB_REQUIRE_COMMIT_MESSAGE")
 	defer os.Unsetenv("MOB_REQUIRE_COMMIT_MESSAGE")
@@ -632,6 +637,12 @@ func TestCleanMissingBaseBranch(t *testing.T) {
 }
 
 func TestStartUnstagedChanges(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	output, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
 	createFile(t, "test.txt", "contentIrrelevant")
@@ -655,6 +666,12 @@ func TestStartIncludeUnstagedChanges(t *testing.T) {
 }
 
 func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	output, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = true
 	Debug = true
@@ -669,6 +686,12 @@ func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
 }
 
 func TestStartHasUnpushedCommits(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	output, configuration := setup(t)
 	createFileAndCommitIt(t, "test.txt", "contentIrrelevant", "unpushed change")
 
@@ -698,6 +721,12 @@ func TestStartIncludeUntrackedFiles(t *testing.T) {
 }
 
 func TestStartUntrackedFiles(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	_, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
 	createFile(t, "example.txt", "contentIrrelevant")
@@ -708,6 +737,12 @@ func TestStartUntrackedFiles(t *testing.T) {
 }
 
 func TestStartOnUnpushedFeatureBranch(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	output, configuration := setup(t)
 	git("checkout", "-b", "feature1")
 
@@ -1137,6 +1172,12 @@ func TestStartNextFeatureBranch(t *testing.T) {
 }
 
 func TestStartDoneLocalFeatureBranch(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	output, configuration := setup(t)
 	git("checkout", "-b", "feature1")
 
@@ -1244,6 +1285,12 @@ func TestStartNextPushManualCommitsFeatureBranch(t *testing.T) {
 }
 
 func TestConflictingMobSessions(t *testing.T) {
+	exitOld := exit
+	exit = func(code int) {
+
+	}
+	defer func() { exit = exitOld }()
+
 	_, configuration := setup(t)
 
 	setWorkingDir(tempDir + "/local")

--- a/mob_test.go
+++ b/mob_test.go
@@ -257,11 +257,6 @@ func TestNextNotMobProgramming(t *testing.T) {
 
 func TestRequireCommitMessage(t *testing.T) {
 	output, _ := setup(t)
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
 
 	os.Unsetenv("MOB_REQUIRE_COMMIT_MESSAGE")
 	defer os.Unsetenv("MOB_REQUIRE_COMMIT_MESSAGE")
@@ -637,12 +632,6 @@ func TestCleanMissingBaseBranch(t *testing.T) {
 }
 
 func TestStartUnstagedChanges(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	output, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
 	createFile(t, "test.txt", "contentIrrelevant")
@@ -666,12 +655,6 @@ func TestStartIncludeUnstagedChanges(t *testing.T) {
 }
 
 func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	output, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = true
 	Debug = true
@@ -686,12 +669,6 @@ func TestStartIncludeUnstagedChangesInNewWorkingDirectory(t *testing.T) {
 }
 
 func TestStartHasUnpushedCommits(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	output, configuration := setup(t)
 	createFileAndCommitIt(t, "test.txt", "contentIrrelevant", "unpushed change")
 
@@ -721,12 +698,6 @@ func TestStartIncludeUntrackedFiles(t *testing.T) {
 }
 
 func TestStartUntrackedFiles(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	_, configuration := setup(t)
 	configuration.StartIncludeUncommittedChanges = false
 	createFile(t, "example.txt", "contentIrrelevant")
@@ -737,12 +708,6 @@ func TestStartUntrackedFiles(t *testing.T) {
 }
 
 func TestStartOnUnpushedFeatureBranch(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	output, configuration := setup(t)
 	git("checkout", "-b", "feature1")
 
@@ -1172,12 +1137,6 @@ func TestStartNextFeatureBranch(t *testing.T) {
 }
 
 func TestStartDoneLocalFeatureBranch(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	output, configuration := setup(t)
 	git("checkout", "-b", "feature1")
 
@@ -1285,12 +1244,6 @@ func TestStartNextPushManualCommitsFeatureBranch(t *testing.T) {
 }
 
 func TestConflictingMobSessions(t *testing.T) {
-	exitOld := exit
-	exit = func(code int) {
-
-	}
-	defer func() { exit = exitOld }()
-
 	_, configuration := setup(t)
 
 	setWorkingDir(tempDir + "/local")
@@ -1422,7 +1375,8 @@ func TestIsGitIdentifiesOutsideOfGitRepo(t *testing.T) {
 func TestNotAGitRepoMessage(t *testing.T) {
 	output, _ := setup(t)
 	setWorkingDir(tempDir + "/notgit")
-	sayGitError("TEST", "TEST", errors.New("TEST"))
+	// TODO missing an actual test case here
+	GitErrorToMobResult("TEST", "TEST", errors.New("TEST")).Print()
 	assertOutputContains(t, output, "expecting the current working directory to be a git repository.")
 }
 


### PR DESCRIPTION
Every error will result in an error message displayed and exiting mob with a status code of 1 (nonzero). This was not so previously. I switched all errors to warnings that didn't lead to a failed execution of mob.