### PR TITLE
feature: allow user to define a fixed base branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,11 +296,20 @@ Mob supports you and can automate this step. You just need the configuration opt
 
 For example if you want use IntelliJ the configuration option would look like this: `MOB_OPEN_COMMAND=idea %s`
 
+### Use a fixed base branch
+
+Say your team typically branches off the same primary branch. It is redundant to state the base branch.
+Setting `MOB_FIXED_BASE_BRANCH` can allow you to remove the base branch name from the wip branch naming convention.
+
+For example, without setting `MOB_FIXED_BASE_BRANCH`, you will have `mob/main-feature1` as the wip branch name.
+Setting `MOB_FIXED_BASE_BRANCH=main` will cause the wip branch to be `mob/feature1` instead.
+
 ## More on Installation
 
 ### Known Issues
 
-- When you have an ssh key with a password and you running mob on windows in powershell, you will not be able to enter a password for your ssh key. You can circumvent this problem by using the git bash instead of powershell.
+- When you have an ssh key with a password and you running mob on windows in powershell, you will not be able to enter a
+  password for your ssh key. You can circumvent this problem by using the git bash instead of powershell.
 
 ### Linux Timer
 
@@ -353,6 +362,7 @@ MOB_NOTIFY_MESSAGE="mob next"
 MOB_NEXT_STAY=true
 MOB_START_INCLUDE_UNCOMMITTED_CHANGES=false
 MOB_STASH_NAME="mob-stash-name"
+MOB_FIXED_BASE_BRANCH=""
 MOB_WIP_BRANCH_QUALIFIER=""
 MOB_WIP_BRANCH_QUALIFIER_SEPARATOR="-"
 MOB_WIP_BRANCH_PREFIX="mob/"

--- a/mob_test.go
+++ b/mob_test.go
@@ -77,33 +77,38 @@ func TestParseArgsMessage(t *testing.T) {
 }
 
 func TestDetermineBranches(t *testing.T) {
-	configuration := getDefaultConfiguration()
-	configuration.WipBranchQualifierSeparator = "-"
+	assertDetermineBranches(t, "master", "", []string{}, "", "master", "mob-session")
+	assertDetermineBranches(t, "mob-session", "", []string{}, "", "master", "mob-session")
+	assertDetermineBranches(t, "mob-session", "green", []string{}, "", "master", "mob-session")
 
-	assertDetermineBranches(t, "master", "", []string{}, "master", "mob-session")
-	assertDetermineBranches(t, "mob-session", "", []string{}, "master", "mob-session")
-	assertDetermineBranches(t, "mob-session", "green", []string{}, "master", "mob-session")
+	assertDetermineBranches(t, "master", "green", []string{}, "", "master", "mob/master-green")
+	assertDetermineBranches(t, "mob/master-green", "", []string{}, "", "master", "mob/master-green")
 
-	assertDetermineBranches(t, "master", "green", []string{}, "master", "mob/master-green")
-	assertDetermineBranches(t, "mob/master-green", "", []string{}, "master", "mob/master-green")
+	assertDetermineBranches(t, "master", "test-branch", []string{}, "", "master", "mob/master-test-branch")
+	assertDetermineBranches(t, "mob/master-test-branch", "", []string{}, "", "master", "mob/master-test-branch")
 
-	assertDetermineBranches(t, "master", "test-branch", []string{}, "master", "mob/master-test-branch")
-	assertDetermineBranches(t, "mob/master-test-branch", "", []string{}, "master", "mob/master-test-branch")
+	assertDetermineBranches(t, "feature1", "", []string{}, "", "feature1", "mob/feature1")
+	assertDetermineBranches(t, "mob/feature1", "", []string{}, "", "feature1", "mob/feature1")
+	assertDetermineBranches(t, "mob/feature1-green", "", []string{}, "", "feature1", "mob/feature1-green")
+	assertDetermineBranches(t, "feature1", "green", []string{}, "", "feature1", "mob/feature1-green")
 
-	assertDetermineBranches(t, "feature1", "", []string{}, "feature1", "mob/feature1")
-	assertDetermineBranches(t, "mob/feature1", "", []string{}, "feature1", "mob/feature1")
-	assertDetermineBranches(t, "mob/feature1-green", "", []string{}, "feature1", "mob/feature1-green")
-	assertDetermineBranches(t, "feature1", "green", []string{}, "feature1", "mob/feature1-green")
+	assertDetermineBranches(t, "feature/test", "", []string{"feature/test"}, "", "feature/test", "mob/feature/test")
+	assertDetermineBranches(t, "mob/feature/test", "", []string{"feature/test", "mob/feature/test"}, "", "feature/test", "mob/feature/test")
 
-	assertDetermineBranches(t, "feature/test", "", []string{"feature/test"}, "feature/test", "mob/feature/test")
-	assertDetermineBranches(t, "mob/feature/test", "", []string{"feature/test", "mob/feature/test"}, "feature/test", "mob/feature/test")
+	assertDetermineBranches(t, "feature/test-ch", "", []string{"DPL-2638-update-apis", "DPL-2814-create-project", "feature/test-ch", "fix/smallChanges", "master", "pipeship/pipelineupdate-pipeship-pipeline.yaml"}, "", "feature/test-ch", "mob/feature/test-ch")
 
-	assertDetermineBranches(t, "feature/test-ch", "", []string{"DPL-2638-update-apis", "DPL-2814-create-project", "feature/test-ch", "fix/smallChanges", "master", "pipeship/pipelineupdate-pipeship-pipeline.yaml"}, "feature/test-ch", "mob/feature/test-ch")
+	assertDetermineBranches(t, "mob/feature1", "", []string{}, "main", "main", "mob/feature1")
+	assertDetermineBranches(t, "feature1", "", []string{}, "main", "main", "mob/feature1")
+	assertDetermineBranches(t, "main", "", []string{}, "main", "main", "mob/main")
+	assertDetermineBranches(t, "main", "feature1", []string{}, "main", "main", "mob/feature1")
+	assertDetermineBranches(t, "feature1-wip", "feature1", []string{}, "main", "main", "mob/feature1")
 }
 
-func assertDetermineBranches(t *testing.T, branch string, qualifier string, branches []string, expectedBase string, expectedWip string) {
+func assertDetermineBranches(t *testing.T, branch string, qualifier string, branches []string, fixedBaseBranch string, expectedBase string, expectedWip string) {
 	configuration := getDefaultConfiguration()
 	configuration.WipBranchQualifier = qualifier
+	configuration.FixedBaseBranch = fixedBaseBranch
+
 	baseBranch, wipBranch := determineBranches(newBranch(branch), branches, configuration)
 	equals(t, newBranch(expectedBase), baseBranch)
 	equals(t, newBranch(expectedWip), wipBranch)


### PR DESCRIPTION
Hi new user here. 
Similar to the https://github.com/remotemobprogramming/mob/pull/254, there's another feature that I would like to suggest. My team typically branches out from the main branch and hence it is redundant to have it in the WIP branch name. It only adds more complexity to the WIP branch name. 
 
I recognise that this might not be accepted since it breaks the original branch naming conventions, but I thought to open it up for discussion anyways. I was able to draft out a proof-of-concept without breaking any of the existing tests. 

Thanks for taking a look!