### PR TITLE
Allow setting DoneSquash values via config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.0
 - Add `mob clean` command that removes orphan wip branches that might be a left over of someone else doing a `mob done`. This is especially helpful when using a lot of feature branches. If you call `mob clean` on an orphan wip branch, it will switch you to the base branch, falling back to main/master if the base branch does not exist.
+- The values `squash`, `no-squash` and `squash-wip` for MOB_DONE_SQUASH can be set not only via env var, but now in the .mob configuration file as well.
 
 # 3.0.0
 - **NEW** Mob will automatically open the last modified file of the previous typist in your preferred IDE. Therefore, you need to set the configuration option `MOB_OPEN_COMMAND` to a command which opens your IDE. For example, the open command for IntelliJ is `idea %s`

--- a/mob.go
+++ b/mob.go
@@ -511,17 +511,8 @@ func setBoolean(s *bool, key string, value string) {
 }
 
 func setMobDoneSquash(configuration *Configuration, key string, value string) {
-	boolValue, err := strconv.ParseBool(value)
-	if err != nil {
-		sayWarning("Could not set key from configuration file because value is not parseable (" + key + "=" + value + ")")
-		return
-	}
-	if boolValue {
-		configuration.DoneSquash = Squash
-	} else {
-		configuration.DoneSquash = NoSquash
-	}
-	debugInfo("Overwriting " + key + " =" + strconv.FormatBool(boolValue))
+	configuration.DoneSquash = doneSquash(value)
+	debugInfo("Overwriting " + key + " =" + string(configuration.DoneSquash))
 }
 
 func parseEnvironmentVariables(configuration Configuration) Configuration {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1405,6 +1405,7 @@ func TestGitStatusWithManyFiles(t *testing.T) {
 
 func TestSetMobDoneSquashOldBehaviour(t *testing.T) {
 	configuration := getDefaultConfiguration()
+	configuration.DoneSquash = Squash
 
 	setMobDoneSquash(&configuration, "", "false")
 	equals(t, NoSquash, configuration.DoneSquash)
@@ -1415,6 +1416,7 @@ func TestSetMobDoneSquashOldBehaviour(t *testing.T) {
 
 func TestSetMobDoneSquashNewBehaviour(t *testing.T) {
 	configuration := getDefaultConfiguration()
+	configuration.DoneSquash = Squash
 
 	setMobDoneSquash(&configuration, "", "no-squash")
 	equals(t, NoSquash, configuration.DoneSquash)
@@ -1424,8 +1426,21 @@ func TestSetMobDoneSquashNewBehaviour(t *testing.T) {
 
 	setMobDoneSquash(&configuration, "", "squash-wip")
 	equals(t, SquashWip, configuration.DoneSquash)
+}
+
+func TestSetMobDoneSquashGarbageValue(t *testing.T) {
+	configuration := getDefaultConfiguration()
+	configuration.DoneSquash = NoSquash
 
 	setMobDoneSquash(&configuration, "", "garbage")
+	equals(t, Squash, configuration.DoneSquash)
+}
+
+func TestSetMobDoneSquashEmptyStringValue(t *testing.T) {
+	configuration := getDefaultConfiguration()
+	configuration.DoneSquash = NoSquash
+
+	setMobDoneSquash(&configuration, "", "")
 	equals(t, Squash, configuration.DoneSquash)
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -1403,6 +1403,32 @@ func TestGitStatusWithManyFiles(t *testing.T) {
 	}, status)
 }
 
+func TestSetMobDoneSquashOldBehaviour(t *testing.T) {
+	configuration := getDefaultConfiguration()
+
+	setMobDoneSquash(&configuration, "", "false")
+	equals(t, NoSquash, configuration.DoneSquash)
+
+	setMobDoneSquash(&configuration, "", "true")
+	equals(t, Squash, configuration.DoneSquash)
+}
+
+func TestSetMobDoneSquashNewBehaviour(t *testing.T) {
+	configuration := getDefaultConfiguration()
+
+	setMobDoneSquash(&configuration, "", "no-squash")
+	equals(t, NoSquash, configuration.DoneSquash)
+
+	setMobDoneSquash(&configuration, "", "squash")
+	equals(t, Squash, configuration.DoneSquash)
+
+	setMobDoneSquash(&configuration, "", "squash-wip")
+	equals(t, SquashWip, configuration.DoneSquash)
+
+	setMobDoneSquash(&configuration, "", "garbage")
+	equals(t, Squash, configuration.DoneSquash)
+}
+
 func gitStatus() GitStatus {
 	shortStatus := silentgit("status", "--short")
 	statusLines := strings.Split(shortStatus, "\n")


### PR DESCRIPTION
In #253 the feature is mentioned that the three new DoneSquash values can be set via env var right now. This PR allows setting these values via config file, too.

Note: there is a change in behaviour if a garbage value is passed. Before we would issue a warning. Now we match the env var behaviour (no warning, set "squash" value).

Signed-off-by: Thomas Much <github@snailshell.de>