### PR TITLE
Support both unquoted and quoted DoneSquash values in config file

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -511,6 +511,14 @@ func setBoolean(s *bool, key string, value string) {
 }
 
 func setMobDoneSquash(configuration *Configuration, key string, value string) {
+	if strings.HasPrefix(value, "\"") {
+		unquotedValue, err := strconv.Unquote(value)
+		if err != nil {
+			sayWarning("Could not set key from configuration file because value is not parseable (" + key + "=" + value + ")")
+			return
+		}
+		value = unquotedValue
+	}
 	configuration.DoneSquash = doneSquash(value)
 	debugInfo("Overwriting " + key + " =" + string(configuration.DoneSquash))
 }

--- a/mob_test.go
+++ b/mob_test.go
@@ -384,6 +384,16 @@ func TestReadConfigurationFromFileOverrideEverything(t *testing.T) {
 	equals(t, "Room\"\"_42", actualConfiguration1.TimerRoom)
 }
 
+func TestReadConfigurationFromFileWithNonBooleanQuotedDoneSquashValue(t *testing.T) {
+	Debug = true
+	tempDir = t.TempDir()
+	setWorkingDir(tempDir)
+
+	createFile(t, ".mob", "\nMOB_DONE_SQUASH=\"squash-wip\"")
+	actualConfiguration := parseUserConfiguration(getDefaultConfiguration(), tempDir+"/.mob")
+	equals(t, SquashWip, actualConfiguration.DoneSquash)
+}
+
 func TestReadConfigurationFromFileAndSkipBrokenLines(t *testing.T) {
 	Debug = true
 	tempDir = t.TempDir()


### PR DESCRIPTION
With #256 it was possible to set the DoneSquash values via config file. However, this only worked for unquoted values. Now both unquoted and quoted values are supported.

The unquoted variant is still necessary for backwards compatibility when boolean values are assigned.

Signed-off-by: Thomas Much <github@snailshell.de>