### PR TITLE
Add link to fig shell autocompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ Examples:
   mob moo
 ```
 
+If you need some assistance when typing the subcommands and options, you might want to have a look at [fig](https://fig.io/) which gives you autocompletion in your shell.
+
 ## Best Practices
 
 - **Say out loud**


### PR DESCRIPTION
Autocompletion for `mob` is available in the latest stable release from "fig" now.

Is this link enough (IMHO yes)? Or should I supply a screenshot as well?