### PR TITLE
Document short command aliases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,5 +62,5 @@ rm /usr/local/bin/mob
 it works like this:
 
 ```
-brew link remotemobprogramming/brew/mob
+brew unlink mob && brew link mob
 ```

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ Timer Commands:
   start <minutes>    start mob session in wip branch and a <minutes> timer
   break <minutes>    start a <minutes> break timer
 
+Short Commands (Options and descriptions as above):
+  s                  alias for 'start'
+  n                  alias for 'next'
+  d                  alias for 'done'
+  b                  alias for 'branch'
+  t                  alias for 'timer'
+
 Get more information:
   status             show the status of the current session
   fetch              fetch remote state

--- a/mob.go
+++ b/mob.go
@@ -1620,6 +1620,13 @@ Timer Commands:
   start <minutes>    start mob session in wip branch and a <minutes> timer
   break <minutes>    start a <minutes> break timer
 
+Short Commands (Options and descriptions as above):
+  s                  alias for 'start'
+  n                  alias for 'next'
+  d                  alias for 'done'
+  b                  alias for 'branch'
+  t                  alias for 'timer'
+
 Get more information:
   status             show the status of the current session
   fetch              fetch remote state


### PR DESCRIPTION
I documented the already existing short command aliases in the README and in the man page.

Is this too verbose, too long output? I tried something like

"For some commands there are short aliases available: s (start), n (next), d (done), b (branch), t (timer)"

as a single line below the "Add --debug ..." line. But I think the longer form in this PR is more readable.