### PR TITLE
Test behaviour on pre existing commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.5
+- Fix: `mob done --squash-wip` now successfully auto-merges auto-mergeable diverging changes.
+
 # 3.1.4
 - Fixes a bug where mob saves the wrong filepath of the last modfied file in the wip commit message.
 

--- a/mob.go
+++ b/mob.go
@@ -1425,7 +1425,7 @@ func done(configuration Configuration) {
 
 		git("checkout", baseBranch.Name)
 		git("merge", baseBranch.remote(configuration).Name, "--ff-only")
-		mergeFailed := gitignorefailure("merge", squashOrNoCommit(configuration), "--ff", wipBranch.Name)
+		mergeFailed := gitignorefailure("merge", squashOrCommit(configuration), "--ff", wipBranch.Name)
 
 		if mergeFailed != nil {
 			// TODO should this be an error and a fix for that error?
@@ -1473,11 +1473,11 @@ func gitRootDir() string {
 	return strings.TrimSuffix(gitDir(), "/.git")
 }
 
-func squashOrNoCommit(configuration Configuration) string {
+func squashOrCommit(configuration Configuration) string {
 	if configuration.DoneSquash == Squash {
 		return "--squash"
 	} else {
-		return "--no-commit"
+		return "--commit"
 	}
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -912,6 +912,51 @@ func TestStartDoneWithMobDoneSquash(t *testing.T) {
 	assertNoMobSessionBranches(t, configuration, "mob-session")
 }
 
+func TestStartDoneSquashWithUnpushedCommit(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.DoneSquash = Squash
+
+	// now in /local
+	createFileAndCommitIt(t, "file1.txt", "owqe", "not a mob session yet")
+
+	setWorkingDir(tempDir + "/alice")
+	start(configuration)
+	createFile(t, "file2.txt", "zcvx")
+	next(configuration)
+
+	setWorkingDir(tempDir + "/local")
+	git("push")
+
+	setWorkingDir(tempDir + "/alice")
+	start(configuration)
+	done(configuration)
+
+	assertFileExist(t, "file1.txt")
+}
+
+func TestStartDoneSquashWipWithUnpushedCommit(t *testing.T) {
+	Debug = true
+	_, configuration := setup(t)
+	configuration.DoneSquash = SquashWip
+
+	// now in /local
+	createFileAndCommitIt(t, "file1.txt", "owqe", "not a mob session yet")
+
+	setWorkingDir(tempDir + "/alice")
+	start(configuration)
+	createFile(t, "file2.txt", "zcvx")
+	next(configuration)
+
+	setWorkingDir(tempDir + "/local")
+	git("push")
+
+	setWorkingDir(tempDir + "/alice")
+	start(configuration)
+	done(configuration)
+
+	assertFileExist(t, "file1.txt")
+}
+
 func TestStartDoneWithMobDoneNoSquash(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.DoneSquash = NoSquash

--- a/mob_test.go
+++ b/mob_test.go
@@ -856,19 +856,6 @@ func TestStartNextStay_OpenLastModifiedFile(t *testing.T) {
 	})
 }
 
-func TestStartDoneWithMobDoneSquash(t *testing.T) {
-	_, configuration := setup(t)
-	configuration.DoneSquash = Squash
-
-	start(configuration)
-	assertOnBranch(t, "mob-session")
-
-	done(configuration)
-
-	assertOnBranch(t, "master")
-	assertNoMobSessionBranches(t, configuration, "mob-session")
-}
-
 func TestRunOutput(t *testing.T) {
 	_, configuration := setup(t)
 
@@ -910,6 +897,19 @@ func TestTestbed(t *testing.T) {
 	assertOutputContains(t, &output, "localother")
 	assertOutputContains(t, &output, "alice")
 	assertOutputContains(t, &output, "bob")
+}
+
+func TestStartDoneWithMobDoneSquash(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.DoneSquash = Squash
+
+	start(configuration)
+	assertOnBranch(t, "mob-session")
+
+	done(configuration)
+
+	assertOnBranch(t, "master")
+	assertNoMobSessionBranches(t, configuration, "mob-session")
 }
 
 func TestStartDoneWithMobDoneNoSquash(t *testing.T) {

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -12,7 +12,7 @@ type Replacer func(string) string
 
 func squashWip(configuration Configuration) {
 	currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-	mergeBase := silentgit("merge-base", currentWipBranch.String(), currentBaseBranch.String())
+	mergeBase := silentgit("merge-base", currentWipBranch.String(), currentBaseBranch.remote(configuration).String())
 
 	originalGitEditor, originalGitSequenceEditor := getEnvGitEditor()
 	setEnvGitEditor(
@@ -23,7 +23,7 @@ func squashWip(configuration Configuration) {
 	git("rebase", "--interactive", "--keep-empty", mergeBase)
 	setEnvGitEditor(originalGitEditor, originalGitSequenceEditor)
 	sayInfo("resulting history is:")
-	sayLastCommitsWithMessage(currentBaseBranch.String(), currentWipBranch.String())
+	sayLastCommitsWithMessage(currentBaseBranch.remote(configuration).String(), currentWipBranch.String())
 	if lastCommitIsWipCommit(configuration) { // last commit is wip commit
 		sayInfo("undoing the final wip commit and staging its changes:")
 		git("reset", "--soft", "HEAD^")


### PR DESCRIPTION
Found and addressed a bug where when one of the mobbers has had an unpushed commit thus other mobbers were behind on the base branch. They ran into a problem when they would do `mob done --squash-wip`