### PR TITLE
Add reference to Chocolatey to install on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ On Windows via [Scoop](https://scoop.sh/):
 scoop install mob
 ```
 
+or via [Chocolatey](https://chocolatey.org/)
+
+```bash
+choco install mob
+```
+
 On Arch Linux via yay:
 
 ```bash


### PR DESCRIPTION
I've created [a Chocolatey package for mob](https://community.chocolatey.org/packages/mob) and thought it might be helpful to add a reference in the README. Thanks!