### PR TITLE
Show help output whenever any kind of help argument is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.1.5
+- Print the help output whenever any kind of help argument (`help`, `--help`, `-h`) is present in the command, e.g. `mob s 10 -h`.
+
 # 3.1.4
 - Fixes a bug where mob saves the wrong filepath of the last modfied file in the wip commit message.
 

--- a/mob.go
+++ b/mob.go
@@ -718,6 +718,10 @@ func parseArgs(args []string, configuration Configuration) (command string, para
 }
 
 func execute(command string, parameter []string, configuration Configuration) {
+	if helpRequested(parameter) {
+		help(configuration)
+		return
+	}
 
 	switch command {
 	case "s", "start":
@@ -779,6 +783,16 @@ func execute(command string, parameter []string, configuration Configuration) {
 	default:
 		help(configuration)
 	}
+}
+
+func helpRequested(parameter []string) bool {
+	for i := 0; i < len(parameter); i++ {
+		element := parameter[i]
+		if element == "help" || element == "--help" || element == "-h" {
+			return true
+		}
+	}
+	return false
 }
 
 func clean(configuration Configuration) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -420,6 +420,16 @@ func TestExecuteInvalidCommandKicksOffHelp(t *testing.T) {
 	assertOutputContains(t, output, "Basic Commands:")
 }
 
+func TestExecuteAnyCommandWithHelpArgumentShowsHelpOutput(t *testing.T) {
+	output, _ := setup(t)
+
+	execute("s", []string{"10", "--help"}, getDefaultConfiguration())
+	assertOutputContains(t, output, "Basic Commands:")
+
+	execute("next", []string{"help"}, getDefaultConfiguration())
+	assertOutputContains(t, output, "Basic Commands:")
+}
+
 func TestStart(t *testing.T) {
 	_, configuration := setup(t)
 
@@ -1479,6 +1489,14 @@ func TestSetMobDoneSquashEmptyStringValue(t *testing.T) {
 
 	setMobDoneSquash(&configuration, "", "")
 	equals(t, Squash, configuration.DoneSquash)
+}
+
+func TestHelpRequested(t *testing.T) {
+	equals(t, false, helpRequested([]string{""}))
+	equals(t, false, helpRequested([]string{"a", "mob", "21"}))
+	equals(t, true, helpRequested([]string{"--help"}))
+	equals(t, true, helpRequested([]string{"a", "help", "12"}))
+	equals(t, true, helpRequested([]string{"s", "10", "-h"}))
 }
 
 func gitStatus() GitStatus {


### PR DESCRIPTION
As a naïve user (no remembering that the tool has only one help page) I expect to get some help for the `start` command (options that can be specified) when executing `mob start --help`. Instead, a mob session started requiring some manual clean-up from my part afterwards.

I would like to change the behavior in the way that whenever there is some help option in the command, the tool prints the help page.