### PR TITLE
[#293] Mob timer should work anywhere on the system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 3.1.5
 - Add a more specific error message if `git` is not installed.
+- Allow for using `mob timer` outside of git repositories.
 - Fix: `mob done --squash-wip` now successfully auto-merges auto-mergeable diverging changes.
 - Print the help output whenever any kind of help argument (`help`, `--help`, `-h`) is present in the command, e.g. `mob s 10 -h`.
 - Various fixes in suggestion of next typist:

--- a/mob.go
+++ b/mob.go
@@ -951,6 +951,11 @@ func startTimer(timerInMinutes string, configuration Configuration) {
 }
 
 func getMobTimerRoom(configuration Configuration) string {
+	if !isGit() {
+		debugInfo("timer not in git repository, using MOB_TIMER_ROOM for room name")
+		return configuration.TimerRoom
+	}
+
 	currentWipBranchQualifier := configuration.WipBranchQualifier
 	if currentWipBranchQualifier == "" {
 		currentBranch := gitCurrentBranch()
@@ -966,6 +971,7 @@ func getMobTimerRoom(configuration Configuration) string {
 		sayInfo("Using wip branch qualifier for room name")
 		return currentWipBranchQualifier
 	}
+
 	return configuration.TimerRoom
 }
 

--- a/mob.go
+++ b/mob.go
@@ -956,16 +956,7 @@ func getMobTimerRoom(configuration Configuration) string {
 		return configuration.TimerRoom
 	}
 
-	currentWipBranchQualifier := configuration.WipBranchQualifier
-	if currentWipBranchQualifier == "" {
-		currentBranch := gitCurrentBranch()
-		currentBaseBranch, _ := determineBranches(currentBranch, gitBranches(), configuration)
-
-		if currentBranch.IsWipBranch(configuration) {
-			wipBranchWithoutWipPrefix := currentBranch.removeWipPrefix(configuration).Name
-			currentWipBranchQualifier = removePrefix(removePrefix(wipBranchWithoutWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
-		}
-	}
+	currentWipBranchQualifier := getCurrentWipBranchQualifier(configuration)
 
 	if configuration.TimerRoomUseWipBranchQualifier && currentWipBranchQualifier != "" {
 		sayInfo("Using wip branch qualifier for room name")
@@ -973,6 +964,20 @@ func getMobTimerRoom(configuration Configuration) string {
 	}
 
 	return configuration.TimerRoom
+}
+
+func getCurrentWipBranchQualifier(configuration Configuration) string {
+	if configuration.WipBranchQualifier == "" {
+		currentBranch := gitCurrentBranch()
+		currentBaseBranch, _ := determineBranches(currentBranch, gitBranches(), configuration)
+
+		if currentBranch.IsWipBranch(configuration) {
+			wipBranchWithoutWipPrefix := currentBranch.removeWipPrefix(configuration).Name
+			return removePrefix(removePrefix(wipBranchWithoutWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
+		}
+	}
+
+	return configuration.WipBranchQualifier
 }
 
 func startBreakTimer(timerInMinutes string, configuration Configuration) {

--- a/mob.go
+++ b/mob.go
@@ -956,7 +956,16 @@ func getMobTimerRoom(configuration Configuration) string {
 		return configuration.TimerRoom
 	}
 
-	currentWipBranchQualifier := getCurrentWipBranchQualifier(configuration)
+	currentWipBranchQualifier := configuration.WipBranchQualifier
+	if currentWipBranchQualifier == "" {
+		currentBranch := gitCurrentBranch()
+		currentBaseBranch, _ := determineBranches(currentBranch, gitBranches(), configuration)
+
+		if currentBranch.IsWipBranch(configuration) {
+			wipBranchWithoutWipPrefix := currentBranch.removeWipPrefix(configuration).Name
+			currentWipBranchQualifier = removePrefix(removePrefix(wipBranchWithoutWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
+		}
+	}
 
 	if configuration.TimerRoomUseWipBranchQualifier && currentWipBranchQualifier != "" {
 		sayInfo("Using wip branch qualifier for room name")
@@ -964,20 +973,6 @@ func getMobTimerRoom(configuration Configuration) string {
 	}
 
 	return configuration.TimerRoom
-}
-
-func getCurrentWipBranchQualifier(configuration Configuration) string {
-	if configuration.WipBranchQualifier == "" {
-		currentBranch := gitCurrentBranch()
-		currentBaseBranch, _ := determineBranches(currentBranch, gitBranches(), configuration)
-
-		if currentBranch.IsWipBranch(configuration) {
-			wipBranchWithoutWipPrefix := currentBranch.removeWipPrefix(configuration).Name
-			return removePrefix(removePrefix(wipBranchWithoutWipPrefix, currentBaseBranch.Name), configuration.WipBranchQualifierSeparator)
-		}
-	}
-
-	return configuration.WipBranchQualifier
 }
 
 func startBreakTimer(timerInMinutes string, configuration Configuration) {


### PR DESCRIPTION
I've added a check for git availability in `getMobTimerRoom` method to allow it to work anywhere in the system.

So, now the behaviour is like this:
- If git repository -> works as it worked before
- If not a git repository -> use the room name from `MOB_TIMER_ROOM` 

---
I wonder if the code, especially `mob.go` file, shouldn't be somehow split into smaller files? It's slightly difficult to work with.
I have not much experience in Go and maybe that's not a good idea to separate all that stuff? I feel like it would make it easier to test it at least. 


