### PR TITLE
Add a new command line argument for for disabling SSL verification

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -697,6 +697,7 @@ func config(c Configuration) {
 	say("MOB_TIMER_LOCAL" + "=" + strconv.FormatBool(c.TimerLocal))
 	say("MOB_TIMER_USER" + "=" + quote(c.TimerUser))
 	say("MOB_TIMER_URL" + "=" + quote(c.TimerUrl))
+	say("MOB_TIMER_INSECURE" + "=" + strconv.FormatBool(c.TimerInsecure))
 }
 
 func quote(value string) string {
@@ -1092,8 +1093,8 @@ func sendRequest(requestBody []byte, requestMethod string, requestUrl string, di
 		switch e.Err.(type) {
 		case x509.UnknownAuthorityError:
 			sayError("The timer.mob.sh SSL certificate is signed by an unknown authority!")
-			sayFix("HINT: You can ignore that by adding MOB_TIMER_INSECURE=true to your configuration or environment. Or add is command line parameter:",
-				"mob <your command> --timer-insecure")
+			sayFix("HINT: You can ignore that by adding MOB_TIMER_INSECURE=true to your configuration or environment.",
+				"echo MOB_TIMER_INSECURE=true >> ~/.mob")
 			return fmt.Errorf("failed, to amke the http request: %w", responseErr)
 
 		default:

--- a/mob.go
+++ b/mob.go
@@ -1072,7 +1072,7 @@ func sendRequest(requestBody []byte, requestMethod string, requestUrl string, di
 	sayInfo(requestMethod + " " + requestUrl + " " + string(requestBody))
 
 	responseBody := bytes.NewBuffer(requestBody)
-	request, requestCreationError := http.NewRequest(requestMethod, requestUrl, responseBody)
+	request, requestCreationError := http.NewRequest(requestMethod, "https://untrusted-root.badssl.com/", responseBody)
 
 	httpClient := http.DefaultClient
 	if disableSSLVerification {
@@ -1092,7 +1092,8 @@ func sendRequest(requestBody []byte, requestMethod string, requestUrl string, di
 		switch e.Err.(type) {
 		case x509.UnknownAuthorityError:
 			sayError("The timer.mob.sh SSL certificate is signed by an unknown authority!")
-			sayError("HINT: You can ignore that by adding MOB_TIMER_INSECURE=true to your configuration or environment.")
+			sayFix("HINT: You can ignore that by adding MOB_TIMER_INSECURE=true to your configuration or environment. Or add is command line parameter:",
+				"mob <your command> --timer-insecure")
 			return fmt.Errorf("failed, to amke the http request: %w", responseErr)
 
 		default:

--- a/mob.go
+++ b/mob.go
@@ -1073,7 +1073,7 @@ func sendRequest(requestBody []byte, requestMethod string, requestUrl string, di
 	sayInfo(requestMethod + " " + requestUrl + " " + string(requestBody))
 
 	responseBody := bytes.NewBuffer(requestBody)
-	request, requestCreationError := http.NewRequest(requestMethod, "https://untrusted-root.badssl.com/", responseBody)
+	request, requestCreationError := http.NewRequest(requestMethod, requestUrl, responseBody)
 
 	httpClient := http.DefaultClient
 	if disableSSLVerification {

--- a/mob.go
+++ b/mob.go
@@ -951,7 +951,7 @@ func startTimer(timerInMinutes string, configuration Configuration) {
 
 	if startRemoteTimer {
 		timerUser := getUserForMobTimer(configuration.TimerUser)
-		err := httpPutTimer(timeoutInMinutes, room, timerUser, configuration)
+		err := httpPutTimer(timeoutInMinutes, room, timerUser, configuration.TimerUrl, configuration.TimerInsecure)
 		if err != nil {
 			sayError("remote timer couldn't be started")
 			sayError(err.Error())
@@ -1015,7 +1015,7 @@ func startBreakTimer(timerInMinutes string, configuration Configuration) {
 
 	if startRemoteTimer {
 		timerUser := getUserForMobTimer(configuration.TimerUser)
-		err := httpPutBreakTimer(timeoutInMinutes, room, timerUser, configuration)
+		err := httpPutBreakTimer(timeoutInMinutes, room, timerUser, configuration.TimerUrl, configuration.TimerInsecure)
 
 		if err != nil {
 			sayError("remote break timer couldn't be started")
@@ -1052,27 +1052,27 @@ func toMinutes(timerInMinutes string) int {
 	return timeoutInMinutes
 }
 
-func httpPutTimer(timeoutInMinutes int, room, timerUser string, config Configuration) error {
+func httpPutTimer(timeoutInMinutes int, room string, user string, timerService string, disableSSLVerification bool) error {
 	putBody, _ := json.Marshal(map[string]interface{}{
 		"timer": timeoutInMinutes,
-		"user":  timerUser,
+		"user":  user,
 	})
-	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerInsecure)
+	return sendRequest(putBody, "PUT", timerService+room, disableSSLVerification)
 }
 
-func httpPutBreakTimer(timeoutInMinutes int, room, timerUser string, config Configuration) error {
+func httpPutBreakTimer(timeoutInMinutes int, room string, user string, timerService string, disableSSLVerification bool) error {
 	putBody, _ := json.Marshal(map[string]interface{}{
 		"breaktimer": timeoutInMinutes,
-		"user":       timerUser,
+		"user":       user,
 	})
-	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerInsecure)
+	return sendRequest(putBody, "PUT", timerService+room, disableSSLVerification)
 }
 
 func sendRequest(requestBody []byte, requestMethod string, requestUrl string, disableSSLVerification bool) error {
 	sayInfo(requestMethod + " " + requestUrl + " " + string(requestBody))
 
 	responseBody := bytes.NewBuffer(requestBody)
-	request, requestCreationError := http.NewRequest(requestMethod, "https://untrusted-root.badssl.com/", responseBody)
+	request, requestCreationError := http.NewRequest(requestMethod, requestUrl, responseBody)
 
 	httpClient := http.DefaultClient
 	if disableSSLVerification {

--- a/mob.go
+++ b/mob.go
@@ -72,7 +72,7 @@ type Configuration struct {
 	TimerRoomUseWipBranchQualifier bool   // override with MOB_TIMER_ROOM_USE_WIP_BRANCH_QUALIFIER
 	TimerUser                      string // override with MOB_TIMER_USER
 	TimerUrl                       string // override with MOB_TIMER_URL
-	TimerDisableSSLVerification    bool   // override with MOB_TIMER_INSECURE
+	TimerInsecure                  bool   // override with MOB_TIMER_INSECURE
 }
 
 func (c Configuration) wipBranchQualifierSuffix() string {
@@ -419,7 +419,7 @@ func parseUserConfiguration(configuration Configuration, path string) Configurat
 		case "MOB_STASH_NAME":
 			setUnquotedString(&configuration.StashName, key, value)
 		case "MOB_TIMER_INSECURE":
-			setBoolean(&configuration.TimerDisableSSLVerification, key, value)
+			setBoolean(&configuration.TimerInsecure, key, value)
 
 		default:
 			continue
@@ -495,6 +495,8 @@ func parseProjectConfiguration(configuration Configuration, path string) Configu
 			setUnquotedString(&configuration.TimerUrl, key, value)
 		case "MOB_STASH_NAME":
 			setUnquotedString(&configuration.StashName, key, value)
+		case "MOB_TIMER_INSECURE":
+			setBoolean(&configuration.TimerInsecure, key, value)
 
 		default:
 			continue
@@ -582,7 +584,7 @@ func parseEnvironmentVariables(configuration Configuration) Configuration {
 	setBoolFromEnvVariable(&configuration.TimerLocal, "MOB_TIMER_LOCAL")
 	setStringFromEnvVariable(&configuration.TimerUser, "MOB_TIMER_USER")
 	setStringFromEnvVariable(&configuration.TimerUrl, "MOB_TIMER_URL")
-	setBoolFromEnvVariable(&configuration.TimerDisableSSLVerification, "MOB_TIMER_INSECURE")
+	setBoolFromEnvVariable(&configuration.TimerInsecure, "MOB_TIMER_INSECURE")
 
 	return configuration
 }
@@ -1055,7 +1057,7 @@ func httpPutTimer(timeoutInMinutes int, room, timerUser string, config Configura
 		"timer": timeoutInMinutes,
 		"user":  timerUser,
 	})
-	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerDisableSSLVerification)
+	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerInsecure)
 }
 
 func httpPutBreakTimer(timeoutInMinutes int, room, timerUser string, config Configuration) error {
@@ -1063,7 +1065,7 @@ func httpPutBreakTimer(timeoutInMinutes int, room, timerUser string, config Conf
 		"breaktimer": timeoutInMinutes,
 		"user":       timerUser,
 	})
-	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerDisableSSLVerification)
+	return sendRequest(putBody, "PUT", config.TimerUrl+room, config.TimerInsecure)
 }
 
 func sendRequest(requestBody []byte, requestMethod string, requestUrl string, disableSSLVerification bool) error {


### PR DESCRIPTION
It may happen that the SSL verification fails when the mob user has a bad setup in combination with an stupid enterprise network which does SSL interception.

To circumvent that I added a new CLI parameter which makes it possible to disable the SSL verification.

This CLI parameter should only be used when the user is sure what he/she is doing since it could be a security risk to not to verify the certificate.

See the screenshot of how it works:

<img width="589" alt="Bildschirmfoto 2022-08-15 um 09 53 54" src="https://user-images.githubusercontent.com/48482008/184597468-0b787286-5eaf-4475-9e21-31f72f6a0877.png">
