### PR TITLE
Improve await feedback

### DIFF
--- a/mob_test.go
+++ b/mob_test.go
@@ -1524,7 +1524,7 @@ func assertSingleTimerProcess(t *testing.T) {
 }
 
 func assertNoTimerProcess(t *testing.T) {
-	test.Await(t, func() bool { return 2 == len(findMobTimerProcessIds()) }, "no mob timer process found")
+	test.Await(t, func() bool { return 0 == len(findMobTimerProcessIds()) }, "no mob timer process found")
 }
 
 func TestAbortBreakTimerIfNewBreakTimerIsStarted(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1520,11 +1520,11 @@ func TestAbortTimerIfNewTimerIsStarted(t *testing.T) {
 }
 
 func assertSingleTimerProcess(t *testing.T) {
-	test.Await(t, func() bool { return 1 == len(findMobTimerProcessIds()) })
+	test.Await(t, func() bool { return 1 == len(findMobTimerProcessIds()) }, "exactly 1 mob timer process found")
 }
 
 func assertNoTimerProcess(t *testing.T) {
-	test.Await(t, func() bool { return 0 == len(findMobTimerProcessIds()) })
+	test.Await(t, func() bool { return 2 == len(findMobTimerProcessIds()) }, "no mob timer process found")
 }
 
 func TestAbortBreakTimerIfNewBreakTimerIsStarted(t *testing.T) {

--- a/test/test.go
+++ b/test/test.go
@@ -19,7 +19,7 @@ var (
 
 const (
 	AWAIT_DEFAULT_POLL_INTERVAL = 100 * time.Millisecond
-	AWAIT_DEFAULT_AT_MOST       = 5 * time.Second
+	AWAIT_DEFAULT_AT_MOST       = 2 * time.Second
 )
 
 func Equals(t *testing.T, exp, act interface{}) {

--- a/test/test.go
+++ b/test/test.go
@@ -78,11 +78,11 @@ func AssertOutputNotContains(t *testing.T, output *string, notContains string) {
 	}
 }
 
-func Await(t *testing.T, until func() bool) {
-	AwaitBlocking(t, AWAIT_DEFAULT_POLL_INTERVAL, AWAIT_DEFAULT_AT_MOST, until)
+func Await(t *testing.T, until func() bool, awaitedState string) {
+	AwaitBlocking(t, AWAIT_DEFAULT_POLL_INTERVAL, AWAIT_DEFAULT_AT_MOST, until, awaitedState)
 }
 
-func AwaitBlocking(t *testing.T, pollInterval time.Duration, atMost time.Duration, until func() bool) {
+func AwaitBlocking(t *testing.T, pollInterval time.Duration, atMost time.Duration, until func() bool, awaitedState string) {
 	if pollInterval <= 0 {
 		failWithFailureMessage(t, fmt.Sprintf("PollInterval cannot be 0 or below, got: %d", pollInterval))
 		return
@@ -105,7 +105,7 @@ func AwaitBlocking(t *testing.T, pollInterval time.Duration, atMost time.Duratio
 			timeLeft = atMost - time.Now().Sub(startTime)
 			if timeLeft <= 0 {
 				stackTrace := string(debug.Stack())
-				failWithFailureMessage(t, fmt.Sprintf("Timeout Error: %s", stackTrace))
+				failWithFailureMessage(t, fmt.Sprintf("expected '%s' to occur within %s but did not: %s", awaitedState, atMost, stackTrace))
 				return
 			}
 		}


### PR DESCRIPTION
Notice, the failing Test now says why it fails:
`expected 'exactly 1 mob timer process found' to occur within 2s but did not: goroutine 5588 [running]:`