### PR TITLE
ci with custom git version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,11 +5,30 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        git-version: [latest, 2.37.0]
     runs-on: ${{ matrix.os }}
     steps:
+    - uses: actions/checkout@v2
+    - name: Install old git version (macOS)
+      if: ${{ matrix.os == 'macos-latest' && matrix.git-version != 'latest'}}
+      run: |
+        brew tap-new mob/local-git
+        brew extract --version=${{ matrix.git-version }} git mob/local-git
+        brew install git@${{ matrix.git-version }} || brew link --overwrite git@${{ matrix.git-version }}
+    - name: Install old git version (ubuntu)
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.git-version != 'latest'}}
+      run: |
+        sudo apt-get update
+        sudo apt-get install gettext asciidoc docbook2x
+        curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.0.tar.gz --output git-${{ matrix.git-version }}.tar.gz
+        tar -zxf git-${{ matrix.git-version }}.tar.gz
+        cd git-${{ matrix.git-version }}
+        make configure
+        ./configure --prefix=/usr
+        make all info
+        sudo make install install-info
     - name: Show git version
       run: git version
-    - uses: actions/checkout@v2
     - name: Use Go 1.16.x
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
I adjusted the CI pipeline, such that it can be tested with different git versions. I would propose to go with latest and with the minimum git version we want to support. I do not know if we somewhere tell the user a minimum git version. Which version should we add here as minimum version @simonharrer @gregorriegler ? 