### PR TITLE
Fix cli name detection on Windows

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -16,6 +16,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strconv"
@@ -220,11 +221,7 @@ func main() {
 }
 
 func currentCliName(argZero string) string {
-	argZero = strings.TrimSuffix(argZero, ".exe")
-	if strings.Contains(argZero, "/") {
-		argZero = argZero[strings.LastIndex(argZero, "/")+1:]
-	}
-	return argZero
+	return strings.TrimSuffix(filepath.Base(argZero), ".exe")
 }
 
 func execute(command string, parameter []string, configuration config.Configuration) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -30,6 +30,9 @@ func TestCurrentCliName(t *testing.T) {
 	equals(t, "mob", currentCliName("mob.exe"))
 	equals(t, "mob", currentCliName("./mob"))
 	equals(t, "mob", currentCliName("folder/mob"))
+	// Check with platform specific path separators as well
+	equals(t, "mob", currentCliName(filepath.Join("folder", "another", "mob.exe")))
+	equals(t, "other_name", currentCliName(filepath.Join("folder", "another", "other_name")))
 }
 
 func TestDetermineBranches(t *testing.T) {


### PR DESCRIPTION
This PR changes `currentCliName` to use `path/filepath` for path manipulation and closes #322 .