### PR TITLE
Fix squash wip tests on Windows

### DIFF
--- a/squash_wip.go
+++ b/squash_wip.go
@@ -78,8 +78,9 @@ func mobExecutable() string {
 }
 
 func isTestEnvironment() bool {
-	return strings.HasSuffix(os.Args[0], ".test") ||
-		strings.HasSuffix(os.Args[0], "_test") ||
+	cliName := currentCliName(os.Args[0])
+	return strings.HasSuffix(cliName, ".test") ||
+		strings.HasSuffix(cliName, "_test") ||
 		os.Args[1] == "-test.v"
 }
 

--- a/squash_wip.go
+++ b/squash_wip.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
@@ -71,6 +72,8 @@ func getEnvGitEditor() (gitEditor string, gitSequenceEditor string) {
 func mobExecutable() string {
 	if isTestEnvironment() {
 		wd, _ := os.Getwd()
+		// Convert Windows path separators to /, so they work in git bash. No-op for non-Windows paths.
+		wd = filepath.ToSlash(wd)
 		return "cd " + wd + " && go run $(ls -1 ./*.go | grep -v _test.go)"
 	} else {
 		return "mob"


### PR DESCRIPTION
This PR fixes #336 by using the `currentCliName` to trim the excess ".exe" part of the executable name in `isTestEnvironment`.
It also fixes the path separators in the command returned by `mobExecutable`, so they work correctly in the git bash environment they are going to get executed at.