### PR TITLE
Fix tests on Windows

### DIFF
--- a/coauthors_test.go
+++ b/coauthors_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -39,12 +37,7 @@ func TestStartDoneCoAuthors(t *testing.T) {
 	start(configuration)
 	done(configuration)
 
-	outputFile := filepath.Join(tempDir, "local", ".git", "SQUASH_MSG")
-	content, err := os.ReadFile(outputFile)
-	if err != nil {
-		failWithFailure(t, fmt.Sprintf("reading file %s failed with %v", outputFile, err), "error")
-	}
-	output := string(content)
+	output := readFile(t, filepath.Join(tempDir, "local", ".git", "SQUASH_MSG"))
 
 	// don't include the person running `mob done`
 	assertOutputNotContains(t, &output, "Co-authored-by: local <local@example.com>")

--- a/coauthors_test.go
+++ b/coauthors_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -36,12 +39,17 @@ func TestStartDoneCoAuthors(t *testing.T) {
 	start(configuration)
 	done(configuration)
 
-	output := run(t, "cat", tempDir+"/local/.git/SQUASH_MSG")
+	outputFile := filepath.Join(tempDir, "local", ".git", "SQUASH_MSG")
+	content, err := os.ReadFile(outputFile)
+	if err != nil {
+		failWithFailure(t, fmt.Sprintf("reading file %s failed with %v", outputFile, err), "error")
+	}
+	output := string(content)
 
 	// don't include the person running `mob done`
-	assertOutputNotContains(t, output, "Co-authored-by: local <local@example.com>")
+	assertOutputNotContains(t, &output, "Co-authored-by: local <local@example.com>")
 	// include everyone else in commit order after removing duplicates
-	assertOutputContains(t, output, "\nCo-authored-by: bob <bob@example.com>\nCo-authored-by: alice <alice@example.com>\nCo-authored-by: localother <localother@example.com>\n")
+	assertOutputContains(t, &output, "\nCo-authored-by: bob <bob@example.com>\nCo-authored-by: alice <alice@example.com>\nCo-authored-by: localother <localother@example.com>\n")
 }
 
 func TestCreateCommitMessage(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1247,7 +1247,7 @@ func TestStartNextFeatureBranch(t *testing.T) {
 func TestGitRootDir(t *testing.T) {
 	setup(t)
 	expectedPath, _ := filepath.EvalSymlinks(tempDir + "/local")
-	equals(t, expectedPath, gitRootDir())
+	equals(t, expectedPath, filepath.FromSlash(gitRootDir()))
 }
 
 func TestGitRootDirWithSymbolicLink(t *testing.T) {
@@ -1255,7 +1255,7 @@ func TestGitRootDirWithSymbolicLink(t *testing.T) {
 	symlinkDir := tempDir + "/local-symlink"
 	setWorkingDir(symlinkDir)
 	expectedLocalSymlinkPath, _ := filepath.EvalSymlinks(symlinkDir)
-	equals(t, expectedLocalSymlinkPath, gitRootDir())
+	equals(t, expectedLocalSymlinkPath, filepath.FromSlash(gitRootDir()))
 }
 
 func TestBothCreateNonemptyCommitWithNext(t *testing.T) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -841,7 +841,11 @@ func TestStartNextStay_DoNotWriteLastModifiedFileInCommit_WhenFileIsMoved(t *tes
 func TestStartNextStay_OpenLastModifiedFile(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.NextStay = true
-	configuration.OpenCommand = "touch %s-1"
+	if runtime.GOOS == "windows" {
+		configuration.OpenCommand = "cmd.exe /C type nul > %s-1"
+	} else {
+		configuration.OpenCommand = "touch %s-1"
+	}
 
 	start(configuration)
 	createFile(t, "file.txt", "contentIrrelevant")

--- a/mob_test.go
+++ b/mob_test.go
@@ -805,11 +805,7 @@ func TestStartNextStay_DoNotWriteLastModifiedFileInCommit_WhenFileIsDeleted(t *t
 	next(configuration)
 
 	start(configuration)
-	file1Path := filepath.Join(workingDir, "file1.txt")
-	err := os.Remove(file1Path)
-	if err != nil {
-		failWithFailure(t, "no error", fmt.Sprintf("error %v occured deleting file %s", err, file1Path))
-	}
+	removeFile(t, filepath.Join(workingDir, "file1.txt"))
 	next(configuration)
 
 	assertOnBranch(t, "mob-session")
@@ -826,12 +822,7 @@ func TestStartNextStay_DoNotWriteLastModifiedFileInCommit_WhenFileIsMoved(t *tes
 
 	start(configuration)
 	createDirectory(t, "dir")
-	oldPath := filepath.Join(workingDir, "file1.txt")
-	newPath := filepath.Join(workingDir, "dir", "file1.txt")
-	err := os.Rename(oldPath, newPath)
-	if err != nil {
-		failWithFailure(t, "no error", fmt.Sprintf("error %v occured moving %s to %s", err, oldPath, newPath))
-	}
+	moveFile(t, filepath.Join(workingDir, "file1.txt"), filepath.Join(workingDir, "dir", "file1.txt"))
 	next(configuration)
 
 	assertOnBranch(t, "mob-session")
@@ -865,12 +856,7 @@ func TestRunOutput(t *testing.T) {
 	setWorkingDir(tempDir + "/local")
 	start(configuration)
 	createFile(t, "file1.txt", "asdf")
-	outputFile := filepath.Join(tempDir, "local", "file1.txt")
-	content, err := os.ReadFile(outputFile)
-	if err != nil {
-		failWithFailure(t, "no error", fmt.Sprintf("error %v occured reading %s", err, outputFile))
-	}
-	output := string(content)
+	output := readFile(t, filepath.Join(tempDir, "local", "file1.txt"))
 	assertOutputContains(t, &output, "asdf")
 }
 
@@ -1769,6 +1755,29 @@ func createDirectoryInPath(t *testing.T, path, directory string) (pathToFile str
 		failWithFailure(t, "creating directory "+pathToFile, "error")
 	}
 	return
+}
+
+func removeFile(t *testing.T, path string) {
+	err := os.Remove(path)
+	if err != nil {
+		failWithFailure(t, "no error", fmt.Sprintf("error %v occured deleting file %s", err, path))
+	}
+}
+
+func moveFile(t *testing.T, oldPath string, newPath string) {
+	err := os.Rename(oldPath, newPath)
+	if err != nil {
+		failWithFailure(t, "no error", fmt.Sprintf("error %v occured moving %s to %s", err, oldPath, newPath))
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		failWithFailure(t, "no error", fmt.Sprintf("reading file %s failed with %v", path, err))
+	}
+	output := string(content)
+	return output
 }
 
 func assertOnBranch(t *testing.T, branch string) {


### PR DESCRIPTION
This PR fixes #339. It removes the `run` function from `mob_test.go` and replaces the usages with go `os.*` calls.
The PR also fixes `gitRootDir()` comparisons on Windows and the Unix `touch` utility usage in `TestStartNextStay_DoNotWriteLastModifiedFileInCommit_WhenFileIsMoved` .