### PR TITLE
Check if git version is at least 2.13.0

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -26,10 +26,8 @@ import (
 )
 
 const (
-	versionNumber          = "4.0.1"
-	minimumGitVersionMajor = 2
-	minimumGitVersionMinor = 13
-	minimumGitVersionPatch = 0
+	versionNumber     = "4.0.1"
+	minimumGitVersion = "2.13.0"
 )
 
 var (
@@ -234,17 +232,17 @@ func main() {
 	say.TurnOnDebuggingByArgs(os.Args)
 	say.Debug(runtime.Version())
 
-	versionString, currentVersion := gitVersion()
+	versionString := gitVersion()
 	if versionString == "" {
 		say.Error("'git' command was not found in PATH. It may be not installed. " +
 			"To learn how to install 'git' refer to https://git-scm.com/book/en/v2/Getting-Started-Installing-Git.")
 		exit(1)
 	}
 
-	if currentVersion.Less(GitVersion{minimumGitVersionMajor, minimumGitVersionMinor, minimumGitVersionPatch}) {
-		say.Error(fmt.Sprintf("'git' command version '%s' is lower than the required minimum version (%d.%d.%d). "+
-			"Please update your 'git' installation!",
-			versionString, minimumGitVersionMajor, minimumGitVersionMinor, minimumGitVersionPatch))
+	currentVersion := parseGitVersion(versionString)
+	if currentVersion.Less(parseGitVersion(minimumGitVersion)) {
+		say.Error(fmt.Sprintf("'git' command version '%s' is lower than the required minimum version (%s). "+
+			"Please update your 'git' installation!", versionString, minimumGitVersion))
 		exit(1)
 	}
 
@@ -1433,14 +1431,13 @@ func gitCommitHash() string {
 	return silentgitignorefailure("rev-parse", "HEAD")
 }
 
-func gitVersion() (string, GitVersion) {
+func gitVersion() string {
 	_, output, err := runCommandSilent("git", "--version")
 	if err != nil {
 		say.Debug("gitVersion encountered an error: " + err.Error())
-		return "", GitVersion{}
+		return ""
 	}
-	versionString := strings.TrimSpace(output)
-	return versionString, parseGitVersion(versionString)
+	return strings.TrimSpace(output)
 }
 
 func isGit() bool {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1581,6 +1581,34 @@ func TestAbortTimerIfMobDone(t *testing.T) {
 	assertNoTimerProcess(t)
 }
 
+func TestGitVersionParse(t *testing.T) {
+	// Check real examples
+	equals(t, GitVersion{2, 34, 1}, parseGitVersion("git version 2.34.1"))
+	equals(t, GitVersion{2, 38, 1}, parseGitVersion("git version 2.38.1.windows.1"))
+	// Check missing prefix
+	equals(t, GitVersion{1, 2, 3}, parseGitVersion("git 1.2.3"))
+	equals(t, GitVersion{4, 5, 6}, parseGitVersion("4.5.6"))
+	// Check missing minor and patch
+	equals(t, GitVersion{2, 5, 0}, parseGitVersion("git version 2.5"))
+	equals(t, GitVersion{2, 0, 0}, parseGitVersion("git version 2"))
+	equals(t, GitVersion{4, 0, 0}, parseGitVersion("4"))
+	// Invalid versions
+	equals(t, GitVersion{0, 0, 0}, parseGitVersion("not version"))
+	equals(t, GitVersion{2, 0, 0}, parseGitVersion("2.xyz3.5"))
+	equals(t, GitVersion{2, 0, 0}, parseGitVersion("2.9999999999999999999999.5"))
+}
+
+func TestGitVersionCompare(t *testing.T) {
+	// Check real examples
+	equals(t, true, (&GitVersion{2, 12, 0}).Less(GitVersion{2, 13, 0}))
+	equals(t, false, (&GitVersion{2, 13, 0}).Less(GitVersion{2, 13, 0}))
+	equals(t, false, (&GitVersion{2, 14, 0}).Less(GitVersion{2, 13, 0}))
+	// Test each part of the version number
+	equals(t, true, (&GitVersion{1, 2, 3}).Less(GitVersion{5, 2, 3}))
+	equals(t, true, (&GitVersion{1, 2, 3}).Less(GitVersion{1, 5, 3}))
+	equals(t, true, (&GitVersion{1, 2, 3}).Less(GitVersion{1, 2, 5}))
+}
+
 func gitStatus() GitStatus {
 	shortStatus := silentgit("status", "--short")
 	statusLines := strings.Split(shortStatus, "\n")


### PR DESCRIPTION
This PR fixes #332 by adding the checks for the required minimum version.
I used a bit more lenient regexp for parsing the git version, since git version strings can be customized during the git commands `./configure` step.

I'm not a 100% sure about adding `minimumGitVersion*` to the const section, adding a single GitVersion struct would have been more elegant, but that can only go in the golbal var section.