### PR TITLE
Fixes Squash wip losing changes without start

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -1146,6 +1146,7 @@ func done(configuration config.Configuration) {
 
 	if wipBranch.hasRemoteBranch(configuration) {
 		if configuration.DoneSquash == config.SquashWip {
+			git("pull")
 			squashWip(configuration)
 		}
 		uncommittedChanges := hasUncommittedChanges()

--- a/mob.go
+++ b/mob.go
@@ -1146,7 +1146,7 @@ func done(configuration config.Configuration) {
 
 	if wipBranch.hasRemoteBranch(configuration) {
 		if configuration.DoneSquash == config.SquashWip {
-			git("pull")
+			git("merge", "FETCH_HEAD", "--ff-only")
 			squashWip(configuration)
 		}
 		uncommittedChanges := hasUncommittedChanges()

--- a/mob_test.go
+++ b/mob_test.go
@@ -1206,6 +1206,29 @@ func TestStartDoneSquashWipOnlyManualCommits(t *testing.T) {
 	assertNoMobSessionBranches(t, configuration, "mob-session")
 }
 
+func TestDoneSquashWipWithoutStartDoesNotLooseChanges(t *testing.T) {
+	_, configuration := setup(t)
+
+	setWorkingDir(tempDir + "/local")
+	start(configuration)
+	createFileAndCommitIt(t, "file1.txt", "owqe", "not a mob session yet")
+	configuration.NextStay = true
+	next(configuration)
+
+	setWorkingDir(tempDir + "/alice")
+	start(configuration)
+	createFile(t, "file2.txt", "zcvx")
+	next(configuration)
+
+	setWorkingDir(tempDir + "/local")
+	assertOnBranch(t, "mob-session")
+	configuration.DoneSquash = config.SquashWip
+	done(configuration)
+
+	assertOnBranch(t, "master")
+	assertFileExist(t, "file2.txt")
+}
+
 func TestStartDoneFeatureBranch(t *testing.T) {
 	_, configuration := setup(t)
 	git("checkout", "-b", "feature1")


### PR DESCRIPTION
Fixes #348 by pulling before squashing.

It's a very simple fix.
What do you think?

Another Idea would be to warn the user that they didn't start or something. 
But that might be more complicated.