### PR TITLE
fix: deprecated set-output in GitHub Action workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
         if: matrix.os == 'darwin' || matrix.os == 'linux'
         id: shasum
         run: |
-          echo ::set-output name=sha_${{matrix.os}}::"$(shasum -a 256 *.tar.gz | awk '{printf $1}')"
+          echo "sha=\"$(shasum -a 256 *.tar.gz | awk '{printf $1}')\"" >> $GITHUB_OUTPUT
       - name: Set up Homebrew
         if: matrix.os == 'darwin'
         id: set-up-homebrew


### PR DESCRIPTION
Due to deprecation of `save-state` and `set-output` commands in GitHub Action workflows, this PR should prevent workflows to fail after the 31st May 2023.

Link to GitHub blogg:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

fix #379 