### PR TITLE
Open last modified file with spaces in path

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -41,7 +41,11 @@ func openCommandFor(c config.Configuration, filepath string) (string, []string) 
 	if !c.IsOpenCommandGiven() {
 		return "", []string{}
 	}
-	split := strings.Split(injectCommandWithMessage(c.OpenCommand, filepath), " ")
+	filepathWithoutSpaces := strings.ReplaceAll(filepath, " ", "&spc&")
+	split := strings.Split(injectCommandWithMessage(c.OpenCommand, filepathWithoutSpaces), " ")
+	for i := 0; i < len(split); i++ {
+		split[i] = strings.ReplaceAll(split[i], "&spc&", " ")
+	}
 	return split[0], split[1:]
 }
 
@@ -938,6 +942,9 @@ func openLastModifiedFileIfPresent(configuration config.Configuration) {
 		return
 	}
 	lastModifiedFile := split[1]
+	if strings.Contains(lastModifiedFile, "\"") {
+		lastModifiedFile, _ = strconv.Unquote(lastModifiedFile)
+	}
 	if lastModifiedFile == "" {
 		say.Debug("Could not find last modified file in commit message")
 		return

--- a/mob.go
+++ b/mob.go
@@ -942,7 +942,7 @@ func openLastModifiedFileIfPresent(configuration config.Configuration) {
 		return
 	}
 	lastModifiedFile := split[1]
-	if strings.Contains(lastModifiedFile, "\"") {
+	if strings.HasPrefix(lastModifiedFile, "\"") {
 		lastModifiedFile, _ = strconv.Unquote(lastModifiedFile)
 	}
 	if lastModifiedFile == "" {

--- a/mob_test.go
+++ b/mob_test.go
@@ -1904,8 +1904,12 @@ func gitStatus() GitStatus {
 		if len(line) == 0 {
 			continue
 		}
-		file := strings.Fields(line)
-		statusMap[strings.Join(file[1:], " ")] = file[0]
+		fields := strings.Fields(line)
+		file := strings.Join(fields[1:], " ")
+		if strings.HasPrefix(file, "\"") {
+			file, _ = strconv.Unquote(file)
+		}
+		statusMap[file] = fields[0]
 	}
 	return statusMap
 }

--- a/mob_test.go
+++ b/mob_test.go
@@ -885,6 +885,27 @@ func TestStartNextStay_OpenLastModifiedFile(t *testing.T) {
 	})
 }
 
+func TestStartNextStay_OpenLastModifiedFile_WhenLastModifiedFilePathContainsSpaces(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.NextStay = true
+	if runtime.GOOS == "windows" {
+		configuration.OpenCommand = "cmd.exe /C type nul > %s-1"
+	} else {
+		configuration.OpenCommand = "touch %s-1"
+	}
+
+	start(configuration)
+	createFile(t, "file with spaces.txt", "contentIrrelevant")
+	assertOnBranch(t, "mob-session")
+	next(configuration)
+
+	start(configuration)
+
+	assertGitStatus(t, GitStatus{
+		"file with spaces.txt-1": "??",
+	})
+}
+
 func TestRunOutput(t *testing.T) {
 	_, configuration := setup(t)
 
@@ -1884,7 +1905,7 @@ func gitStatus() GitStatus {
 			continue
 		}
 		file := strings.Fields(line)
-		statusMap[file[1]] = file[0]
+		statusMap[strings.Join(file[1:], " ")] = file[0]
 	}
 	return statusMap
 }


### PR DESCRIPTION
This is my attempt to allow opening last modified files when the project path on disk contains spaces. I also opened issue  #387 with further details.

The test I added works with a last modified file containing spaces instead of a project path containing spaces, as this was way easier to set up for me and seems to exhibit the same behavior.

As I have no prior experience with Go, I assume my code is not idiomatic. Also, I have not yet extracted functions yet. Therefore, feedback about how my code better fits into the codebase is greatly appreciated.