### PR TITLE
Fix uninstall instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,11 +414,22 @@ For your name to show up in the room at timer.mob.sh you must set a timer value 
 Mob can simply be uninstalled by removing the installed binary (at least if it was installed via the http://install.mob.sh script). 
 
 ### Linux
-    rm /usr/local/bin/mob
+
+```bash
+rm /usr/local/bin/mob
+```
+
 ### Windows (Git Bash)
-    rm ~/bin/mob.exe
+
+```bash
+rm ~/bin/mob.exe
+```
+
 ### MacOS
-    brew uninstall remotemobprogramming/brew/mob
+
+```bash
+brew uninstall remotemobprogramming/brew/mob
+```
 
 ## How to contribute
 


### PR DESCRIPTION
Uninstall instructions are rendering incorrectly on https://mob.sh/

<img width="1030" alt="Screenshot 2023-07-10 at 1 41 16 PM" src="https://github.com/remotemobprogramming/mob/assets/42837121/389f88ea-6f14-42fa-9d0b-affba1e72d3c">

This PR should fix that.