### PR TITLE
Remove redundant word in fix message

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -833,7 +833,7 @@ func start(configuration config.Configuration) error {
 
 	if !currentBaseBranch.hasRemoteBranch(configuration) && !configuration.StartCreate {
 		say.Error("Remote branch " + currentBaseBranch.remote(configuration).String() + " is missing")
-		say.Fix("To start and and create the remote branch", "mob start --create")
+		say.Fix("To start and create the remote branch", "mob start --create")
 		return errors.New("remote branch is missing")
 	}
 


### PR DESCRIPTION
Just removing the word "and" appearing twice in a message.

<img width="1034" alt="Capture d’écran 2023-12-14 à 21 20 55" src="https://github.com/remotemobprogramming/mob/assets/5627688/58069bef-4a84-4d03-9243-fdc255a0a540">
