### PR TITLE
#410: added duration to latest commit for a remote branch to mob status

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	versionNumber     = "4.5.0"
+	versionNumber     = "4.5.1"
 	minimumGitVersion = "2.13.0"
 )
 
@@ -887,16 +887,6 @@ func warnForActiveWipBranches(configuration config.Configuration, currentBaseBra
 	}
 }
 
-func showActiveMobSessions(configuration config.Configuration, currentBaseBranch Branch) {
-	existingWipBranches := getWipBranchesForBaseBranch(currentBaseBranch, configuration)
-	if len(existingWipBranches) > 0 {
-		say.Info("remote wip branches detected:")
-		for _, wipBranch := range existingWipBranches {
-			say.WithPrefix(wipBranch, "  - ")
-		}
-	}
-}
-
 func sayUntrackedFilesInfo() {
 	untrackedFiles := getUntrackedFiles()
 	hasUntrackedFiles := len(untrackedFiles) > 0
@@ -1187,19 +1177,6 @@ func squashOrCommit(configuration config.Configuration) string {
 		return "--squash"
 	} else {
 		return "--commit"
-	}
-}
-
-func status(configuration config.Configuration) {
-	if isMobProgramming(configuration) {
-		currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-		say.Info("you are on wip branch " + currentWipBranch.String() + " (base branch " + currentBaseBranch.String() + ")")
-
-		sayLastCommitsList(currentBaseBranch.String(), currentWipBranch.String())
-	} else {
-		currentBaseBranch, _ := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
-		say.Info("you are on base branch '" + currentBaseBranch.String() + "'")
-		showActiveMobSessions(configuration, currentBaseBranch)
 	}
 }
 

--- a/mob_test.go
+++ b/mob_test.go
@@ -177,38 +177,6 @@ func TestDoneNotMobProgramming(t *testing.T) {
 	assertOutputContains(t, output, "to start working together")
 }
 
-func TestStatusMobProgramming(t *testing.T) {
-	output, configuration := setup(t)
-	start(configuration)
-
-	status(configuration)
-
-	assertOutputContains(t, output, "you are on wip branch mob-session")
-}
-
-func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
-	output, configuration := setup(t)
-	configuration.NextStay = true
-	start(configuration)
-
-	for i := 0; i < 6; i++ {
-		createFile(t, "test"+strconv.Itoa(i)+".txt", "contentIrrelevant")
-		next(configuration)
-	}
-
-	status(configuration)
-	// 6 wip commits + 1 start commit
-	assertOutputContains(t, output, "wip branch 'mob-session' contains 7 commits.")
-}
-
-func TestExecuteKicksOffStatus(t *testing.T) {
-	output, _ := setup(t)
-
-	execute("status", []string{}, config.GetDefaultConfiguration())
-
-	assertOutputContains(t, output, "you are on base branch 'master'")
-}
-
 func TestExecuteInvalidCommandKicksOffHelp(t *testing.T) {
 	output, _ := setup(t)
 

--- a/status.go
+++ b/status.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	config "github.com/remotemobprogramming/mob/v4/configuration"
+	"github.com/remotemobprogramming/mob/v4/say"
+)
+
+func status(configuration config.Configuration) {
+	if isMobProgramming(configuration) {
+		currentBaseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
+		say.Info("you are on wip branch " + currentWipBranch.String() + " (base branch " + currentBaseBranch.String() + ")")
+
+		sayLastCommitsList(currentBaseBranch.String(), currentWipBranch.String())
+	} else {
+		currentBaseBranch, _ := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
+		say.Info("you are on base branch '" + currentBaseBranch.String() + "'")
+		showActiveMobSessions(configuration, currentBaseBranch)
+	}
+}
+
+func showActiveMobSessions(configuration config.Configuration, currentBaseBranch Branch) {
+	existingWipBranches := getWipBranchesForBaseBranch(currentBaseBranch, configuration)
+	if len(existingWipBranches) > 0 {
+		say.Info("remote wip branches detected:")
+		for _, wipBranch := range existingWipBranches {
+			time := silentgit("log", "-1", "--pretty=format:(%ar)", wipBranch)
+			say.WithPrefix(wipBranch+" "+time, "  - ")
+		}
+	}
+}

--- a/status.go
+++ b/status.go
@@ -26,5 +26,7 @@ func showActiveMobSessions(configuration config.Configuration, currentBaseBranch
 			time := silentgit("log", "-1", "--pretty=format:(%ar)", wipBranch)
 			say.WithPrefix(wipBranch+" "+time, "  - ")
 		}
+	} else {
+		say.Info("no remote wip branches detected!")
 	}
 }

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	config "github.com/remotemobprogramming/mob/v4/configuration"
+	"strconv"
+	"testing"
+)
+
+func TestExecuteKicksOffStatus(t *testing.T) {
+	output, _ := setup(t)
+
+	execute("status", []string{}, config.GetDefaultConfiguration())
+
+	assertOutputContains(t, output, "you are on base branch 'master'")
+}
+
+func TestStatusMobProgramming(t *testing.T) {
+	output, configuration := setup(t)
+	start(configuration)
+
+	status(configuration)
+
+	assertOutputContains(t, output, "you are on wip branch mob-session")
+}
+
+func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
+	output, configuration := setup(t)
+	configuration.NextStay = true
+	start(configuration)
+
+	for i := 0; i < 6; i++ {
+		createFile(t, "test"+strconv.Itoa(i)+".txt", "contentIrrelevant")
+		next(configuration)
+	}
+
+	status(configuration)
+	// 6 wip commits + 1 start commit
+	assertOutputContains(t, output, "wip branch 'mob-session' contains 7 commits.")
+}
+
+func TestStatusDetectsWipBranches(t *testing.T) {
+	output, configuration := setup(t)
+	start(configuration)
+	git("switch", "master")
+
+	status(configuration)
+
+	assertOutputContains(t, output, "remote wip branches detected:\n  - origin/mob-session (0 seconds ago)")
+}

--- a/status_test.go
+++ b/status_test.go
@@ -4,6 +4,7 @@ import (
 	config "github.com/remotemobprogramming/mob/v4/configuration"
 	"strconv"
 	"testing"
+	"time"
 )
 
 func TestExecuteKicksOffStatus(t *testing.T) {
@@ -41,7 +42,10 @@ func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
 func TestStatusDetectsWipBranches(t *testing.T) {
 	output, configuration := setup(t)
 	start(configuration)
+	createFile(t, "test.txt", "contentIrrelevant")
+	next(configuration)
 	git("checkout", "master")
+	time.Sleep(2 * time.Second)
 
 	status(configuration)
 

--- a/status_test.go
+++ b/status_test.go
@@ -41,7 +41,7 @@ func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
 func TestStatusDetectsWipBranches(t *testing.T) {
 	output, configuration := setup(t)
 	start(configuration)
-	git("switch", "master")
+	git("checkout", "master")
 
 	status(configuration)
 

--- a/status_test.go
+++ b/status_test.go
@@ -45,5 +45,6 @@ func TestStatusDetectsWipBranches(t *testing.T) {
 
 	status(configuration)
 
-	assertOutputContains(t, output, "remote wip branches detected:\n  - origin/mob-session (0 seconds ago)")
+	assertOutputContains(t, output, "remote wip branches detected:\n  - origin/mob-session")
+	assertOutputContains(t, output, " seconds ago)")
 }

--- a/status_test.go
+++ b/status_test.go
@@ -4,7 +4,6 @@ import (
 	config "github.com/remotemobprogramming/mob/v4/configuration"
 	"strconv"
 	"testing"
-	"time"
 )
 
 func TestExecuteKicksOffStatus(t *testing.T) {
@@ -45,10 +44,10 @@ func TestStatusDetectsWipBranches(t *testing.T) {
 	createFile(t, "test.txt", "contentIrrelevant")
 	next(configuration)
 	git("checkout", "master")
-	time.Sleep(2 * time.Second)
 
 	status(configuration)
 
 	assertOutputContains(t, output, "remote wip branches detected:\n  - origin/mob-session")
-	assertOutputContains(t, output, " seconds ago)")
+	assertOutputContains(t, output, " second")
+	assertOutputContains(t, output, " ago)")
 }


### PR DESCRIPTION
closes #410 

the result of the change can be seen here. 
```
$ mob status
> you are on base branch 'main'
> remote wip branches detected:
  - origin/mob/main (10 months ago)
  - origin/mob/main-my-feature (1 year, 4 months ago)

```

if there is no remote wip branch:
```
$ mob status
> you are on base branch 'main'
> no remote wip branches detected!
```
