### PR TITLE
WIP: remove empty commit on mob start

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -21,6 +21,7 @@ type Configuration struct {
 	RemoteName                     string // override with MOB_REMOTE_NAME
 	WipCommitMessage               string // override with MOB_WIP_COMMIT_MESSAGE
 	StartCommitMessage             string // override with MOB_START_COMMIT_MESSAGE
+	SkipCiPushOptionEnabled        bool   // override with MOB_SKIP_CI_PUSH_OPTION_ENABLED
 	GitHooksEnabled                bool   // override with MOB_GIT_HOOKS_ENABLED
 	RequireCommitMessage           bool   // override with MOB_REQUIRE_COMMIT_MESSAGE
 	VoiceCommand                   string // override with MOB_VOICE_COMMAND
@@ -75,6 +76,7 @@ func Config(c Configuration) {
 	say.Say("MOB_REMOTE_NAME" + "=" + quote(c.RemoteName))
 	say.Say("MOB_WIP_COMMIT_MESSAGE" + "=" + quote(c.WipCommitMessage))
 	say.Say("MOB_START_COMMIT_MESSAGE" + "=" + quote(c.StartCommitMessage))
+	say.Say("MOB_SKIP_CI_PUSH_OPTION_ENABLED" + "=" + strconv.FormatBool(c.SkipCiPushOptionEnabled))
 	say.Say("MOB_GIT_HOOKS_ENABLED" + "=" + strconv.FormatBool(c.GitHooksEnabled))
 	say.Say("MOB_REQUIRE_COMMIT_MESSAGE" + "=" + strconv.FormatBool(c.RequireCommitMessage))
 	say.Say("MOB_VOICE_COMMAND" + "=" + quote(c.VoiceCommand))
@@ -181,6 +183,7 @@ func GetDefaultConfiguration() Configuration {
 		RemoteName:                     "origin",
 		WipCommitMessage:               "mob next [ci-skip] [ci skip] [skip ci]",
 		StartCommitMessage:             "mob start [ci-skip] [ci skip] [skip ci]",
+		SkipCiPushOptionEnabled:        true,
 		GitHooksEnabled:                false,
 		VoiceCommand:                   voiceCommand,
 		VoiceMessage:                   "mob next",
@@ -237,6 +240,8 @@ func parseUserConfiguration(configuration Configuration, path string) Configurat
 			setUnquotedString(&configuration.WipCommitMessage, key, value)
 		case "MOB_START_COMMIT_MESSAGE":
 			setUnquotedString(&configuration.StartCommitMessage, key, value)
+		case "MOB_SKIP_CI_PUSH_OPTION_ENABLED":
+			setBoolean(&configuration.SkipCiPushOptionEnabled, key, value)
 		case "MOB_GIT_HOOKS_ENABLED":
 			setBoolean(&configuration.GitHooksEnabled, key, value)
 		case "MOB_REQUIRE_COMMIT_MESSAGE":
@@ -328,6 +333,8 @@ func parseProjectConfiguration(configuration Configuration, path string) Configu
 			setUnquotedString(&configuration.WipCommitMessage, key, value)
 		case "MOB_START_COMMIT_MESSAGE":
 			setUnquotedString(&configuration.StartCommitMessage, key, value)
+		case "MOB_SKIP_CI_PUSH_OPTION_ENABLED":
+			setBoolean(&configuration.SkipCiPushOptionEnabled, key, value)
 		case "MOB_GIT_HOOKS_ENABLED":
 			setBoolean(&configuration.GitHooksEnabled, key, value)
 		case "MOB_REQUIRE_COMMIT_MESSAGE":
@@ -420,10 +427,12 @@ func parseEnvironmentVariables(configuration Configuration) Configuration {
 	removed("MOB_WIP_BRANCH", "Use '"+configuration.Mob("start --branch <branch>")+"' instead.")
 	removed("MOB_START_INCLUDE_UNCOMMITTED_CHANGES", "Use the parameter --include-uncommitted-changes instead.")
 	experimental("MOB_WIP_BRANCH_PREFIX")
+	deprecated("MOB_START_COMMIT_MESSAGE", "Please check that everybody you work with uses version 5.0.0 or higher. Then this environment variable can be unset, as it will not have an impact anymore.")
 
 	setStringFromEnvVariable(&configuration.RemoteName, "MOB_REMOTE_NAME")
 	setStringFromEnvVariable(&configuration.WipCommitMessage, "MOB_WIP_COMMIT_MESSAGE")
 	setStringFromEnvVariable(&configuration.StartCommitMessage, "MOB_START_COMMIT_MESSAGE")
+	setBoolFromEnvVariable(&configuration.SkipCiPushOptionEnabled, "MOB_SKIP_CI_PUSH_OPTION_ENABLED")
 	setBoolFromEnvVariable(&configuration.GitHooksEnabled, "MOB_GIT_HOOKS_ENABLED")
 	setBoolFromEnvVariable(&configuration.RequireCommitMessage, "MOB_REQUIRE_COMMIT_MESSAGE")
 	setOptionalStringFromEnvVariable(&configuration.VoiceCommand, "MOB_VOICE_COMMAND")

--- a/mob.go
+++ b/mob.go
@@ -735,15 +735,16 @@ func startNewMobSession(configuration config.Configuration) {
 
 	say.Info("starting new session from " + currentBaseBranch.remote(configuration).String())
 	git("checkout", "-B", currentWipBranch.Name, currentBaseBranch.remote(configuration).Name)
-	gitPush(gitHooksOption(configuration), "--set-upstream", configuration.RemoteName, currentWipBranch.Name+":"+currentWipBranch.Name)
+	gitWithoutEmptyStrings(append(gitPushArgs(configuration), gitHooksOption(configuration), "--set-upstream", configuration.RemoteName, currentWipBranch.Name+":"+currentWipBranch.Name)...)
 }
 
-func gitPush(args ...string) {
-	gitWithoutEmptyStrings(pushArgs(args)...)
-}
-
-func pushArgs(args []string) []string {
-	return append([]string{"push"}, deleteEmptyStrings(args)...)
+func gitPushArgs(c config.Configuration) []string {
+	pushArgs := []string{"push"}
+	if c.SkipCiPushOptionEnabled {
+		return pushArgs
+	} else {
+		return append(pushArgs, "--push-option", "ci.skip")
+	}
 }
 
 func getUntrackedFiles() string {

--- a/mob.go
+++ b/mob.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	versionNumber     = "4.5.1"
+	versionNumber     = "5.0.0"
 	minimumGitVersion = "2.13.0"
 )
 
@@ -735,7 +735,6 @@ func startNewMobSession(configuration config.Configuration) {
 
 	say.Info("starting new session from " + currentBaseBranch.remote(configuration).String())
 	git("checkout", "-B", currentWipBranch.Name, currentBaseBranch.remote(configuration).Name)
-	git("commit", gitHooksOption(configuration), "--allow-empty", "-m", configuration.StartCommitMessage)
 	gitPush(gitHooksOption(configuration), "--set-upstream", configuration.RemoteName, currentWipBranch.Name+":"+currentWipBranch.Name)
 }
 

--- a/squash_wip_test.go
+++ b/squash_wip_test.go
@@ -157,7 +157,6 @@ func TestSquashWipCommits_acceptanceWithDroppingStartCommit(t *testing.T) {
 		"second manual commit",
 		"first manual commit",
 		configuration.WipCommitMessage,
-		configuration.StartCommitMessage,
 	}, commitsOnCurrentBranch(configuration))
 
 	squashWip(configuration)
@@ -186,7 +185,6 @@ func TestCommitsOnCurrentBranch(t *testing.T) {
 	equals(t, []string{
 		configuration.WipCommitMessage,
 		"on branch",
-		configuration.StartCommitMessage,
 	}, commits)
 }
 

--- a/status_test.go
+++ b/status_test.go
@@ -34,8 +34,7 @@ func TestStatusWithMoreThan5LinesOfLog(t *testing.T) {
 	}
 
 	status(configuration)
-	// 6 wip commits + 1 start commit
-	assertOutputContains(t, output, "wip branch 'mob-session' contains 7 commits.")
+	assertOutputContains(t, output, "wip branch 'mob-session' contains 6 commits.")
 }
 
 func TestStatusDetectsWipBranches(t *testing.T) {

--- a/test/test.go
+++ b/test/test.go
@@ -29,6 +29,13 @@ func Equals(t *testing.T, exp, act interface{}) {
 	}
 }
 
+func NotEquals(t *testing.T, exp, act interface{}) {
+	if reflect.DeepEqual(exp, act) {
+		t.Log(string(debug.Stack()))
+		failWithFailure(t, exp, act)
+	}
+}
+
 func failWithFailure(t *testing.T, exp interface{}, act interface{}) {
 	_, file, line, _ := runtime.Caller(1)
 	fmt.Printf("\033[31m%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\033[39m\n\n", filepath.Base(file), line, exp, act)


### PR DESCRIPTION
In this PR i will remove this empty commit when doing mob start as this can lead to branches where someone did a mob start and did not work there and after few weeks we revisit the project and do mob start and do not notice that this is a running session with just the empty commit. 

The main reason for this empty commit was optimization of ci runs. We could again introduce the ci.skip push option and give the user the option to either disable it or to explicitly enable it. I think in the most cases this should not make any problems and could be held that we have a option to disable the option. 

The CI skip options would for example not work on github, but should not be any issue adding the option there. It just will not skip the ci. This is something which hurts less than the empty commit.

closes #408 