### PR TITLE
Use os.UserHomeDir() instead of user.Current() HomeDir to improve Windows performance

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"github.com/remotemobprogramming/mob/v4/say"
 	"os"
-	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -101,8 +100,8 @@ func ReadConfiguration(gitRootDir string) Configuration {
 	configuration := GetDefaultConfiguration()
 	configuration = parseEnvironmentVariables(configuration)
 
-	currentUser, _ := user.Current()
-	userConfigurationPath := currentUser.HomeDir + "/.mob"
+	userHomeDir, _ := os.UserHomeDir()
+	userConfigurationPath := userHomeDir + "/.mob"
 	configuration = parseUserConfiguration(configuration, userConfigurationPath)
 	if gitRootDir != "" {
 		configuration = parseProjectConfiguration(configuration, gitRootDir+"/.mob")


### PR DESCRIPTION
On Windows, I am seeing long command times (10+ seconds) when running mob. I was able to narrow it down to the `user.Current()` call. I assume it takes a long time because my Windows user is managed by an organization domain controller. Switching to `os.UserHomeDir()` fixes this performance problem and `user.Current()` uses that under the hood anyways: https://github.com/golang/go/blob/974b2011ca2a74ca1137558771b428bddb2e7df3/src/os/user/lookup_stubs.go#L32.