### PR TITLE
Add reference to DB Systel in "Who is using 'mob'?"

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ go test -coverprofile=cover.out && go tool cover -html=cover.out
 - [BLUME2000](https://twitter.com/slashBene/status/1337329356637687811?s=20)
 - [REWE Digital](https://www.rewe-digital.com/)
 - [Amadeus IT Group](https://amadeus.com/)
+- [DB Systel GmbH](https://www.dbsystel.de/)
 - [FlixMobility TECH (FlixBus)](https://www.flixbus.com/)
 - And probably many others who shall not be named.
 


### PR DESCRIPTION
Let's add our usage to the Readme (as discussed in a conversation with @simonharrer during the JAX in Mainz).