### PR TITLE
Fix missing directory

### DIFF
--- a/mob_test.go
+++ b/mob_test.go
@@ -2113,8 +2113,12 @@ func createFileInPath(t *testing.T, path, filename, content string) (pathToFile 
 func createExecutableFileInPath(t *testing.T, path, filename, content string) (pathToFile string) {
 	contentAsBytes := []byte(content)
 	pathToFile = path + "/" + filename
-	err := os.WriteFile(pathToFile, contentAsBytes, 0755)
-	if err != nil {
+	err1 := os.MkdirAll(path, 0755)
+	if err1 != nil {
+		failWithFailure(t, "creating folder "+path, "error")
+	}
+	err2 := os.WriteFile(pathToFile, contentAsBytes, 0755)
+	if err2 != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
 	return

--- a/mob_test.go
+++ b/mob_test.go
@@ -2111,30 +2111,27 @@ func createFileInPath(t *testing.T, path, filename, content string) (pathToFile 
 }
 
 func createExecutableFileInPath(t *testing.T, path, filename, content string) (pathToFile string) {
-	contentAsBytes := []byte(content)
+	ensureDirectoryExists(t, path)
+
 	pathToFile = path + "/" + filename
-	err1 := os.MkdirAll(path, 0755)
-	if err1 != nil {
-		failWithFailure(t, "creating folder "+path, "error")
-	}
-	err2 := os.WriteFile(pathToFile, contentAsBytes, 0755)
-	if err2 != nil {
+	contentAsBytes := []byte(content)
+	err := os.WriteFile(pathToFile, contentAsBytes, 0755)
+	if err != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
 	return
 }
 
-func createDirectory(t *testing.T, directory string) (pathToFile string) {
-	return createDirectoryInPath(t, workingDir, directory)
+func createDirectory(t *testing.T, directory string) (pathToDirectory string) {
+	return ensureDirectoryExists(t, workingDir+"/"+directory)
 }
 
-func createDirectoryInPath(t *testing.T, path, directory string) (pathToFile string) {
-	pathToFile = path + "/" + directory
-	err := os.Mkdir(pathToFile, 0755)
+func ensureDirectoryExists(t *testing.T, path string) (pathToDirectory string) {
+	err := os.MkdirAll(path, 0755)
 	if err != nil {
-		failWithFailure(t, "creating directory "+pathToFile, "error")
+		failWithFailure(t, "creating folder "+path, "error")
 	}
-	return
+	return path
 }
 
 func removeFile(t *testing.T, path string) {


### PR DESCRIPTION
TestStartDespiteGitHook failed on my laptop.

Cause: `/.git/hooks` does not get created by default.

Fix: during tests, create directories before adding files to it.