### PR TITLE
Fix #452 installed binary path check on Windows git bash

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -175,7 +175,12 @@ check_say() {
 
 check_installation_path() {
   location="$(command -v mob)"
-  if [ "$location" != "$target/mob" ] && [ "$location" != "" ]; then
+  target_location="$target/mob"
+  if [ "$(determine_os)" == "windows" ]; then
+    location="$(cygpath -m "$location")"
+    target_location="${target_location}.exe"
+  fi
+  if [ "$location" != "$target_location" ] && [ "$location" != "" ]; then
     echo "(!) The installation location doesn't match the location of the mob binary."
     echo "    This means that the binary that's used is not the binary that has just been installed"
     echo "    You probably want to delete the binary at $location"

--- a/install.sh
+++ b/install.sh
@@ -175,12 +175,10 @@ check_say() {
 
 check_installation_path() {
   location="$(command -v mob)"
-  target_location="$target/mob"
   if [ "$(determine_os)" == "windows" ]; then
-    location="$(cygpath -m "$location")"
-    target_location="${target_location}.exe"
+    location=$(echo $location | sed -E 's|^/([a-zA-Z])|\U\1:|; s|/|/|g')
   fi
-  if [ "$location" != "$target_location" ] && [ "$location" != "" ]; then
+  if [ "$location" != "$target/mob" ] && [ "$location" != "" ]; then
     echo "(!) The installation location doesn't match the location of the mob binary."
     echo "    This means that the binary that's used is not the binary that has just been installed"
     echo "    You probably want to delete the binary at $location"

--- a/install.sh
+++ b/install.sh
@@ -176,7 +176,7 @@ check_say() {
 check_installation_path() {
   location="$(command -v mob)"
   if [ "$(determine_os)" == "windows" ]; then
-    location=$(echo $location | sed -E 's|^/([a-zA-Z])|\U\1:|; s|/|/|g')
+    location=$(echo $location | sed -E 's|^/([a-zA-Z])|\U\1:|')
   fi
   if [ "$location" != "$target/mob" ] && [ "$location" != "" ]; then
     echo "(!) The installation location doesn't match the location of the mob binary."


### PR DESCRIPTION
Closes #452

When installing on Windows via git bash, `command -v mob` gives a UNIX style path while `$target` gives a UNIX style path but with a Windows style drive lettering (e.g. "C:/..."), leading to a mismatch.

This patch checks if the system is Windows, and if so, converts the expected path to the same format (Windows style drive lettering, forward slashes) before comparison.