### PR TITLE
Inject http.client into httpclient.SendRequest

### DIFF
--- a/goal/goal.go
+++ b/goal/goal.go
@@ -64,10 +64,8 @@ func putGoalHttp(goal string, configuration config.Configuration) error {
 	if err != nil {
 		return err
 	}
-
 	httpClient := httpclient.GetHttpClient(configuration.TimerInsecure)
 	_, err = httpclient.SendRequest(requestBody, "PUT", getGoalUrl(configuration), httpClient)
-
 	return err
 }
 

--- a/goal/goal.go
+++ b/goal/goal.go
@@ -64,8 +64,8 @@ func putGoalHttp(goal string, configuration config.Configuration) error {
 	if err != nil {
 		return err
 	}
-	httpClient := httpclient.GetHttpClient(configuration.TimerInsecure)
-	_, err = httpclient.SendRequest(requestBody, "PUT", getGoalUrl(configuration), httpClient)
+	client := httpclient.CreateHttpClient(configuration.TimerInsecure)
+	_, err = client.SendRequest(requestBody, "PUT", getGoalUrl(configuration))
 	return err
 }
 
@@ -88,8 +88,8 @@ func deleteGoalHttp(room string, user string, timerService string, disableSslVer
 	if err != nil {
 		return err
 	}
-	httpClient := httpclient.GetHttpClient(disableSslVerification)
-	_, err = httpclient.SendRequest(requestBody, "DELETE", timerService+room+"/goal", httpClient)
+	client := httpclient.CreateHttpClient(disableSslVerification)
+	_, err = client.SendRequest(requestBody, "DELETE", timerService+room+"/goal")
 	return err
 }
 
@@ -108,7 +108,7 @@ func showGoal(configuration config.Configuration) error {
 }
 func getGoalHttp(room string, timerService string, disableSslVerification bool) (string, error) {
 	url := timerService + room + "/goal"
-	response, err := httpclient.GetHttpClient(disableSslVerification).Get(url)
+	response, err := httpclient.GetNetHttpClient(disableSslVerification).Get(url)
 	if err != nil {
 		say.Debug(err.Error())
 		return "", err

--- a/goal/goal.go
+++ b/goal/goal.go
@@ -64,7 +64,10 @@ func putGoalHttp(goal string, configuration config.Configuration) error {
 	if err != nil {
 		return err
 	}
-	_, err = httpclient.SendRequest(requestBody, "PUT", getGoalUrl(configuration), configuration.TimerInsecure)
+
+	httpClient := httpclient.GetHttpClient(configuration.TimerInsecure)
+	_, err = httpclient.SendRequest(requestBody, "PUT", getGoalUrl(configuration), httpClient)
+
 	return err
 }
 
@@ -87,7 +90,8 @@ func deleteGoalHttp(room string, user string, timerService string, disableSslVer
 	if err != nil {
 		return err
 	}
-	_, err = httpclient.SendRequest(requestBody, "DELETE", timerService+room+"/goal", disableSslVerification)
+	httpClient := httpclient.GetHttpClient(disableSslVerification)
+	_, err = httpclient.SendRequest(requestBody, "DELETE", timerService+room+"/goal", httpClient)
 	return err
 }
 

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -22,19 +22,11 @@ func GetHttpClient(disableSSLVerification bool) *http.Client {
 	return http.DefaultClient
 }
 
-func SendRequest(requestBody []byte, requestMethod string, requestUrl string, disableSSLVerification bool) (string, error) {
+func SendRequest(requestBody []byte, requestMethod string, requestUrl string, httpClient *http.Client) (string, error) {
 	say.Info(requestMethod + " " + requestUrl + " " + string(requestBody))
 
 	responseBody := bytes.NewBuffer(requestBody)
 	request, requestCreationError := http.NewRequest(requestMethod, requestUrl, responseBody)
-
-	httpClient := http.DefaultClient
-	if disableSSLVerification {
-		transCfg := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		httpClient = &http.Client{Transport: transCfg}
-	}
 
 	if requestCreationError != nil {
 		return "", fmt.Errorf("failed to create the http request object: %w", requestCreationError)
@@ -72,14 +64,4 @@ func SendRequest(requestBody []byte, requestMethod string, requestUrl string, di
 		say.Info(body)
 	}
 	return body, nil
-}
-
-func getHttpClient(disableSSLVerification bool) *http.Client {
-	if disableSSLVerification {
-		transCfg := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-		return &http.Client{Transport: transCfg}
-	}
-	return http.DefaultClient
 }

--- a/timer.go
+++ b/timer.go
@@ -157,7 +157,8 @@ func httpPutTimer(timeoutInMinutes int, room string, user string, timerService s
 		"timer": timeoutInMinutes,
 		"user":  user,
 	})
-	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, disableSSLVerification)
+	httpClient := httpclient.GetHttpClient(disableSSLVerification)
+	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, httpClient)
 	return err
 }
 
@@ -166,7 +167,8 @@ func httpPutBreakTimer(timeoutInMinutes int, room string, user string, timerServ
 		"breaktimer": timeoutInMinutes,
 		"user":       user,
 	})
-	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, disableSSLVerification)
+	httpClient := httpclient.GetHttpClient(disableSSLVerification)
+	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, httpClient)
 	return err
 }
 

--- a/timer.go
+++ b/timer.go
@@ -157,8 +157,8 @@ func httpPutTimer(timeoutInMinutes int, room string, user string, timerService s
 		"timer": timeoutInMinutes,
 		"user":  user,
 	})
-	httpClient := httpclient.GetHttpClient(disableSSLVerification)
-	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, httpClient)
+	client := httpclient.CreateHttpClient(disableSSLVerification)
+	_, err := client.SendRequest(putBody, "PUT", timerService+room)
 	return err
 }
 
@@ -167,8 +167,8 @@ func httpPutBreakTimer(timeoutInMinutes int, room string, user string, timerServ
 		"breaktimer": timeoutInMinutes,
 		"user":       user,
 	})
-	httpClient := httpclient.GetHttpClient(disableSSLVerification)
-	_, err := httpclient.SendRequest(putBody, "PUT", timerService+room, httpClient)
+	client := httpclient.CreateHttpClient(disableSSLVerification)
+	_, err := client.SendRequest(putBody, "PUT", timerService+room)
 	return err
 }
 


### PR DESCRIPTION
This is a tiny change that refactors httpclient to:

1. Remove `getHttpClient` (which was unused).
2. Inject a `*http.client` into `SendRequest`, rather than having `SendRequest` self-initialise one.
3. Have usages of `SendRequest` initialise a `http.client` using `GetHttpClient`

In terms of logic, things are the same as they were before, with the exception of the request being initialized _after_ the client, instead of before.

Now that `SendRequest` is decoupled from `http.DefaultClient`, it's a little easier to write unit tests for it (which I'd be happy to do)

I'd be super interested in your thoughts on the general theme of doing dependency injection like this.