### PR TITLE
feat: add shortcut for `--create` as `-c`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.3.4
+- Feature: Add shortcut for `mob start --create` as `mob start -c`.
+
 # 5.3.3
 - Fix: `mob start` now functions correctly on WIP branches when the base branch is not checked out, applicable to branch names that do not contain a `-` character.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,14 @@ Running single test files during development is probably easiest in your IDE.
 To check if all tests are passing, simply run
 
 ```
-$ go test -v
+$ go test ./...
 ```
 
-To do some manual testing, you can install the new binary to `/usr/local/bin/`:
+To do some manual testing, you can run it in this repository or install the new binary to `/usr/local/bin/`:
 
 ```
+$ go run .
+OR
 $ ./install
 ```
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Basic Commands(Options):
     [--include-uncommitted-changes|-i]   Move uncommitted changes to wip branch
     [--discard-uncommitted-changes|-d]   Discard uncommitted changes
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>-<branch-postfix>'
-    [--create]                           Create the remote branch
+    [--create|-c]                        Create the remote branch
     [--room <room-name>]                 Set room name for timer.mob.sh once
   next
     [--stay|-s]                          Stay on wip branch (default)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -150,7 +150,7 @@ func ParseArgs(args []string, configuration Configuration) (command string, para
 			newConfiguration.DoneSquash = NoSquash
 		case "--squash-wip":
 			newConfiguration.DoneSquash = SquashWip
-		case "--create":
+		case "--create", "-c":
 			newConfiguration.StartCreate = true
 		case "--join", "-j":
 			newConfiguration.StartJoin = true

--- a/configuration/configuration_test.go
+++ b/configuration/configuration_test.go
@@ -39,6 +39,16 @@ func TestParseArgsStartCreate(t *testing.T) {
 	test.Equals(t, true, configuration.StartCreate)
 }
 
+func TestParseArgsStartCreateShort(t *testing.T) {
+	configuration := GetDefaultConfiguration()
+
+	command, parameters, configuration := ParseArgs([]string{"mob", "start", "-c"}, configuration)
+
+	test.Equals(t, "start", command)
+	test.Equals(t, "", strings.Join(parameters, ""))
+	test.Equals(t, true, configuration.StartCreate)
+}
+
 func TestParseArgsStartJoin(t *testing.T) {
 	configuration := GetDefaultConfiguration()
 

--- a/help/help.go
+++ b/help/help.go
@@ -20,8 +20,8 @@ Basic Commands with Options:
     [--include-uncommitted-changes|-i]   Move uncommitted changes to wip branch
     [--discard-uncommitted-changes|-d]   Discard uncommitted changes
     [--branch|-b <branch-postfix>]       Set wip branch to 'mob/<base-branch>` + configuration.WipBranchQualifierSeparator + `<branch-postfix>'
-    [--create]                           Create the remote branch
-	[--join|-j]                          Join existing wip branch
+    [--create|-c]                        Create the remote branch
+    [--join|-j]                          Join existing wip branch
     [--room <room-name>]                 Set room name for timer.mob.sh once
   next
     [--stay|-s]                          Stay on wip branch (default)

--- a/mob.go
+++ b/mob.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	versionNumber     = "5.3.3"
+	versionNumber     = "5.3.4"
 	minimumGitVersion = "2.13.0"
 )
 


### PR DESCRIPTION
I've added a shortcut for `mob start --create` as `mob start -c`

The "configuration/configuration_test.go" has not been executed with `go test -v`, thus I updated the README with `go test ./...` to run tests in all modules.

Regarding the version update: I was not sure, how your updates work exactly. I've included it in this PR, feel free to remove or update, as you see fit.