### PR TITLE
Avoid git fetch'ing all branches by default

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -550,8 +550,9 @@ func start(configuration config.Configuration) error {
 	}
 
 	currentBranch := gitCurrentBranch()
-	git("fetch", configuration.RemoteName, currentBranch.Name)
-
+	if !configuration.StartCreate {
+		git("fetch", configuration.RemoteName, currentBranch.Name)
+	}
 	currentBaseBranch, currentWipBranch := determineBranches(currentBranch, gitBranches(), configuration)
 
 	if !currentWipBranch.hasRemoteBranch(configuration) && configuration.StartJoin {


### PR DESCRIPTION
On a repo with a significant number of remote branches, fetching all remotes takes a substantial amount of time (literal minutes in our case where there are thousands of remotes)

This changes each `git fetch` call to fetch only the current branch name, and has specialcase handling for the `mob start --create` option where we know we want to create a brand new branch.

Appreciate this might not be a problem for most people!