### PR TITLE
Speed up hasCommits check

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -297,8 +297,8 @@ func run(osArgs []string) {
 }
 
 func hasCommits() bool {
-	commitCount := silentgit("rev-list", "--all", "--count")
-	return commitCount != "0"
+	_, err := silentgitignorefailure("rev-parse", "--verify", "HEAD")
+	return (err == nil)
 }
 
 func currentCliName(argZero string) string {


### PR DESCRIPTION
`git rev-list --all` is very slow for large repositories (order of 5s on a repo with 500k commits).

This alternative version works by checking whether HEAD points at a valid commit.