### PR TITLE
mob start: Checkout base branch locally if it doesnt exist

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -766,6 +766,9 @@ func startJoinMobSession(configuration config.Configuration) {
 	baseBranch, currentWipBranch := determineBranches(gitCurrentBranch(), gitBranches(), configuration)
 
 	say.Info("joining existing session from " + currentWipBranch.remote(configuration).String())
+	if !baseBranch.hasLocalBranch() {
+		git("checkout", baseBranch.Name)
+	}
 	if currentWipBranch.hasLocalBranch() && doBranchesDiverge(baseBranch.remote(configuration).Name, currentWipBranch.Name) {
 		say.Warning("Careful, your wip branch (" + currentWipBranch.Name + ") diverges from your main branch (" + baseBranch.remote(configuration).Name + ") !")
 	}


### PR DESCRIPTION
we were seeing this error when calling `mob next` (base branch is called `register99`):

```
ERROR git --no-pager log register99..mob/register99 --pretty=format:%an --abbrev-commit
ERROR fatal: ambiguous argument 'register99..mob/register99': unknown revision or path not in the working tree.
ERROR Use '--' to separate paths from revisions, like this:
```

I think this happens if someone joins the session by initially checking out the wip branch instead of the base branch?  ie they did `git checkout mob/register99; mob start`, rather than `git checkout register99; mob start`.

so this is very much an edge case / a user having done the "wrong" thing.  

but maybe it's nice to handle this case gracefully anyhow?

(apologies i still haven't figured out the tests)