### PR TITLE
Fix: Handle filenames with spaces in mob next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 5.4.1
+- Fix: `mob next` now correctly handles filenames with spaces when determining the last modified file for the open command.
+
 # 5.4.0
 - Feature: Add shortcut for `mob start --create` as `mob start -c`.
 

--- a/mob.go
+++ b/mob.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	versionNumber     = "5.4.0"
+	versionNumber     = "5.4.1"
 	minimumGitVersion = "2.13.0"
 )
 
@@ -881,7 +881,17 @@ func getPathOfLastModifiedFile() string {
 	}
 
 	for _, file := range files {
-		absoluteFilepath := rootDir + "/" + file
+		unquotedFile := file
+		if strings.HasPrefix(file, "\"") {
+			var err error
+			unquotedFile, err = strconv.Unquote(file)
+			if err != nil {
+				say.Warning("Could not unquote filename from git: " + file)
+				say.Warning(err.Error())
+				continue
+			}
+		}
+		absoluteFilepath := rootDir + "/" + unquotedFile
 		say.Debug(absoluteFilepath)
 		info, err := os.Stat(absoluteFilepath)
 		if err != nil {

--- a/mob_test.go
+++ b/mob_test.go
@@ -859,6 +859,19 @@ func TestStartNextStay_WriteLastModifiedFileInCommit_WhenFileIsModifiedAndWorkin
 	equals(t, silentgit("log", "--format=%B", "-n", "1", "HEAD"), configuration.WipCommitMessage+"\n\nlastFile:file1.txt")
 }
 
+func TestStartNextStay_WriteLastModifiedFileInCommit_WhenFilenameContainsSpaces(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.NextStay = true
+	start(configuration)
+	createFile(t, "file with spaces.txt", "contentIrrelevant")
+	assertOnBranch(t, "mob-session")
+
+	next(configuration)
+
+	equals(t, silentgit("log", "--format=%B", "-n", "1", "HEAD"), configuration.WipCommitMessage+"\n\nlastFile:\"file with spaces.txt\"")
+	assertOnBranch(t, "mob-session")
+}
+
 func TestStartNextStay_DoNotWriteLastModifiedFileInCommit_WhenFileIsDeleted(t *testing.T) {
 	_, configuration := setup(t)
 	configuration.NextStay = true
@@ -2415,4 +2428,19 @@ func getSymlinkGitDirectory(path string) string {
 
 func getSymlinkDirectory(path string) string {
 	return path + "/local-symlink"
+}
+
+func TestGetPathOfLastModifiedFile_HandlesFilenamesWithSpaces(t *testing.T) {
+	_, configuration := setup(t)
+	configuration.NextStay = true
+
+	start(configuration)
+	createFile(t, "file with spaces.txt", "content")
+
+	git("add", "--all")
+	lastFile := getPathOfLastModifiedFile()
+
+	if !strings.Contains(lastFile, "file with spaces.txt") {
+		t.Errorf("Expected lastFile to contain the spaced filename, got: %s", lastFile)
+	}
 }


### PR DESCRIPTION
Git's porcelain output quotes filenames containing spaces. The getPathOfLastModifiedFile function was passing these quoted filenames directly to os.Stat, causing failures on mob next.

- Unquote git-quoted filenames before calling os.Stat.
- Handle unquoting errors gracefully with warning messages.
- Bump version to 5.4.1.