### PR TITLE
Fix lastFile parsing when the commit message has been appended to (e.g. via git hooks)

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -689,7 +689,7 @@ func openLastModifiedFileIfPresent(configuration config.Configuration) {
 		say.Warning("Could not determine last modified file from commit message, separator was used multiple times!")
 		return
 	}
-	lastModifiedFile := split[1]
+	lastModifiedFile := strings.Split(split[1], "\n")[0]
 	if strings.HasPrefix(lastModifiedFile, "\"") {
 		lastModifiedFile, _ = strconv.Unquote(lastModifiedFile)
 	}


### PR DESCRIPTION
Parse only the first line after "lastFile:" to handle cases where git hooks append additional content to WIP commit messages. This fixes MOB_OPEN_COMMAND failures when git hooks modify WIP commits (e.g., adding sign-offs, ticket IDs, or trailers).