### PR TITLE
feat: Add ci.skip push option to mob next

### DIFF
--- a/mob.go
+++ b/mob.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	gitClient = &mobgit.Client{}
-	args []string
+	args      []string
 )
 
 func openCommandFor(c config.Configuration, filepath string) (string, []string) {
@@ -173,7 +173,7 @@ func (branch Branch) exists(existingBranches []string) bool {
 	return stringContains(existingBranches, branch.Name)
 }
 
-func (branch Branch) hasWipBranchQualifierSeparator(configuration config.Configuration) bool { //TODO improve (dont use strings.Contains, add tests)
+func (branch Branch) hasWipBranchQualifierSeparator(configuration config.Configuration) bool { // TODO improve (dont use strings.Contains, add tests)
 	return strings.Contains(branch.Name, configuration.WipBranchQualifierSeparator)
 }
 
@@ -399,7 +399,6 @@ func clean(configuration config.Configuration) {
 			git("branch", "-D", b.Name)
 		}
 	}
-
 }
 
 func (branch Branch) isOrphanWipBranch(configuration config.Configuration) bool {
@@ -472,7 +471,6 @@ func currentTime() string {
 func moo(configuration config.Configuration) {
 	voiceMessage := "moo"
 	err := executeCommandsInBackgroundProcess(getVoiceCommand(voiceMessage, configuration.VoiceCommand))
-
 	if err != nil {
 		say.Warning(fmt.Sprintf("can't run voice command on your system (%s)", runtime.GOOS))
 		say.Warning(err.Error())
@@ -790,13 +788,13 @@ func next(configuration config.Configuration) {
 
 	if isNothingToCommit() {
 		if currentWipBranch.hasLocalCommits(configuration) {
-			gitWithoutEmptyStrings("push", gitHooksOption(configuration), configuration.RemoteName, currentWipBranch.Name)
+			gitWithoutEmptyStrings(append(gitPushArgs(configuration), gitHooksOption(configuration), configuration.RemoteName, currentWipBranch.Name)...)
 		} else {
 			say.Info("nothing was done, so nothing to commit")
 		}
 	} else {
 		makeWipCommit(configuration)
-		gitWithoutEmptyStrings("push", gitHooksOption(configuration), configuration.RemoteName, currentWipBranch.Name)
+		gitWithoutEmptyStrings(append(gitPushArgs(configuration), gitHooksOption(configuration), configuration.RemoteName, currentWipBranch.Name)...)
 	}
 	showNext(configuration)
 

--- a/mob.go
+++ b/mob.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	gitClient = &mobgit.Client{}
-	args      []string
+	args []string
 )
 
 func openCommandFor(c config.Configuration, filepath string) (string, []string) {
@@ -173,7 +173,7 @@ func (branch Branch) exists(existingBranches []string) bool {
 	return stringContains(existingBranches, branch.Name)
 }
 
-func (branch Branch) hasWipBranchQualifierSeparator(configuration config.Configuration) bool { // TODO improve (dont use strings.Contains, add tests)
+func (branch Branch) hasWipBranchQualifierSeparator(configuration config.Configuration) bool { //TODO improve (dont use strings.Contains, add tests)
 	return strings.Contains(branch.Name, configuration.WipBranchQualifierSeparator)
 }
 
@@ -399,6 +399,7 @@ func clean(configuration config.Configuration) {
 			git("branch", "-D", b.Name)
 		}
 	}
+
 }
 
 func (branch Branch) isOrphanWipBranch(configuration config.Configuration) bool {
@@ -471,6 +472,7 @@ func currentTime() string {
 func moo(configuration config.Configuration) {
 	voiceMessage := "moo"
 	err := executeCommandsInBackgroundProcess(getVoiceCommand(voiceMessage, configuration.VoiceCommand))
+
 	if err != nil {
 		say.Warning(fmt.Sprintf("can't run voice command on your system (%s)", runtime.GOOS))
 		say.Warning(err.Error())

--- a/mob_test.go
+++ b/mob_test.go
@@ -2213,7 +2213,7 @@ func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		failWithFailure(t, nil, err)
 	}
-	
+
 }
 
 func assertError(t *testing.T, err error, errorMessage string) {

--- a/mob_test.go
+++ b/mob_test.go
@@ -3,6 +3,12 @@ package main
 import (
 	"fmt"
 	"os"
+
+	config "github.com/remotemobprogramming/mob/v5/configuration"
+	"github.com/remotemobprogramming/mob/v5/exit"
+	"github.com/remotemobprogramming/mob/v5/open"
+	"github.com/remotemobprogramming/mob/v5/say"
+	"github.com/remotemobprogramming/mob/v5/workdir"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -10,12 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-
-	config "github.com/remotemobprogramming/mob/v5/configuration"
-	"github.com/remotemobprogramming/mob/v5/exit"
-	"github.com/remotemobprogramming/mob/v5/open"
-	"github.com/remotemobprogramming/mob/v5/say"
-	"github.com/remotemobprogramming/mob/v5/workdir"
 )
 
 var (
@@ -2079,7 +2079,7 @@ func runMob(t *testing.T, workingDir string, args ...string) {
 func gitStatus() GitStatus {
 	shortStatus := silentgit("status", "--porcelain")
 	statusLines := strings.Split(shortStatus, "\n")
-	statusMap := make(GitStatus)
+	var statusMap = make(GitStatus)
 	for _, line := range statusLines {
 		if len(line) == 0 {
 			continue
@@ -2156,7 +2156,7 @@ func createTestbed(t *testing.T, configuration config.Configuration) {
 
 func createTestbedIn(t *testing.T, temporaryDirectory string) {
 	say.Debug("Creating temporary test assets in " + temporaryDirectory)
-	err := os.MkdirAll(temporaryDirectory, 0o755)
+	err := os.MkdirAll(temporaryDirectory, 0755)
 	if err != nil {
 		say.Error("Could not create temporary dir " + temporaryDirectory)
 		say.Error(err.Error())
@@ -2189,7 +2189,7 @@ func createTestbedIn(t *testing.T, temporaryDirectory string) {
 	}
 
 	notGitDirectory := getNotGitDirectory(temporaryDirectory)
-	err = os.MkdirAll(notGitDirectory, 0o755)
+	err = os.MkdirAll(notGitDirectory, 0755)
 	if err != nil {
 		say.Error("Count not create directory " + notGitDirectory)
 		say.Error(err.Error())
@@ -2213,6 +2213,7 @@ func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		failWithFailure(t, nil, err)
 	}
+	
 }
 
 func assertError(t *testing.T, err error, errorMessage string) {
@@ -2273,7 +2274,7 @@ func createFile(t *testing.T, filename string, content string) (pathToFile strin
 func createFileInPath(t *testing.T, path, filename, content string) (pathToFile string) {
 	contentAsBytes := []byte(content)
 	pathToFile = path + "/" + filename
-	err := os.WriteFile(pathToFile, contentAsBytes, 0o644)
+	err := os.WriteFile(pathToFile, contentAsBytes, 0644)
 	if err != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
@@ -2285,7 +2286,7 @@ func createExecutableFileInPath(t *testing.T, path, filename, content string) (p
 
 	pathToFile = path + "/" + filename
 	contentAsBytes := []byte(content)
-	err := os.WriteFile(pathToFile, contentAsBytes, 0o755)
+	err := os.WriteFile(pathToFile, contentAsBytes, 0755)
 	if err != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
@@ -2297,7 +2298,7 @@ func createDirectory(t *testing.T, directory string) (pathToDirectory string) {
 }
 
 func ensureDirectoryExists(t *testing.T, path string) (pathToDirectory string) {
-	err := os.MkdirAll(path, 0o755)
+	err := os.MkdirAll(path, 0755)
 	if err != nil {
 		failWithFailure(t, "creating folder "+path, "error")
 	}
@@ -2423,7 +2424,7 @@ func cleanRepository(path string) {
 func createRemoteRepository(path string) {
 	branch := "master" // fixed to master for now
 	say.Debug("createremoterepository: Creating remote repository " + path)
-	err := os.MkdirAll(path, 0o755)
+	err := os.MkdirAll(path, 0755)
 	if err != nil {
 		say.Error("Could not create directory " + path)
 		say.Error(err.Error())
@@ -2441,7 +2442,7 @@ func createRemoteRepository(path string) {
 
 func cloneRepository(path, remoteDirectory string) {
 	say.Debug("clonerepository: Cloning remote " + remoteDirectory + " to " + path)
-	err := os.MkdirAll(path, 0o755)
+	err := os.MkdirAll(path, 0755)
 	if err != nil {
 		say.Error("Could not create directory " + path)
 		say.Error(err.Error())

--- a/mob_test.go
+++ b/mob_test.go
@@ -3,12 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	config "github.com/remotemobprogramming/mob/v5/configuration"
-	"github.com/remotemobprogramming/mob/v5/exit"
-	"github.com/remotemobprogramming/mob/v5/open"
-	"github.com/remotemobprogramming/mob/v5/say"
-	"github.com/remotemobprogramming/mob/v5/workdir"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -16,6 +10,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	config "github.com/remotemobprogramming/mob/v5/configuration"
+	"github.com/remotemobprogramming/mob/v5/exit"
+	"github.com/remotemobprogramming/mob/v5/open"
+	"github.com/remotemobprogramming/mob/v5/say"
+	"github.com/remotemobprogramming/mob/v5/workdir"
 )
 
 var (
@@ -241,7 +241,58 @@ func TestStartWithOutCISkip(t *testing.T) {
 	assertMobSessionBranches(t, configuration, "mob-session")
 	assertCommitLogNotContainsMessage(t, "mob-session", configuration.StartCommitMessage)
 	assertOutputNotContains(t, output, "--push-option ci.skip")
+}
 
+func TestNextWithCISkipLocalCommits(t *testing.T) {
+	output, configuration := setup(t)
+	configuration.SkipCiPushOptionEnabled = true
+	mockExit()
+
+	start(configuration)
+	createFileAndCommitIt(t, "example.txt", "asdf", "asdf")
+	next(configuration)
+
+	assertOutputContains(t, output, "git push --push-option ci.skip")
+	assertOutputContains(t, output, "Disable the push option ci.skip in your .mob file or set the expected environment variable")
+	assertOutputContains(t, output, "export MOB_SKIP_CI_PUSH_OPTION_ENABLED=false")
+	resetExit()
+}
+
+func TestNextWithOutCISkipLocalCommits(t *testing.T) {
+	output, configuration := setup(t)
+	configuration.SkipCiPushOptionEnabled = false
+
+	start(configuration)
+	createFileAndCommitIt(t, "example.txt", "asdf", "asdf")
+	next(configuration)
+
+	assertOutputNotContains(t, output, "--push-option ci.skip")
+}
+
+func TestNextWithCISkipSomethingToCommit(t *testing.T) {
+	output, configuration := setup(t)
+	configuration.SkipCiPushOptionEnabled = true
+	mockExit()
+
+	start(configuration)
+	createFile(t, "example.txt", "contentIrrelevant")
+	next(configuration)
+
+	assertOutputContains(t, output, "git push --push-option ci.skip")
+	assertOutputContains(t, output, "Disable the push option ci.skip in your .mob file or set the expected environment variable")
+	assertOutputContains(t, output, "export MOB_SKIP_CI_PUSH_OPTION_ENABLED=false")
+	resetExit()
+}
+
+func TestNextWithOutCISkipSomethingToCommit(t *testing.T) {
+	output, configuration := setup(t)
+	configuration.SkipCiPushOptionEnabled = false
+
+	start(configuration)
+	createFile(t, "example.txt", "contentIrrelevant")
+	next(configuration)
+
+	assertOutputNotContains(t, output, "--push-option ci.skip")
 }
 
 func TestStartWithMultipleExistingBranches(t *testing.T) {
@@ -2028,7 +2079,7 @@ func runMob(t *testing.T, workingDir string, args ...string) {
 func gitStatus() GitStatus {
 	shortStatus := silentgit("status", "--porcelain")
 	statusLines := strings.Split(shortStatus, "\n")
-	var statusMap = make(GitStatus)
+	statusMap := make(GitStatus)
 	for _, line := range statusLines {
 		if len(line) == 0 {
 			continue
@@ -2105,7 +2156,7 @@ func createTestbed(t *testing.T, configuration config.Configuration) {
 
 func createTestbedIn(t *testing.T, temporaryDirectory string) {
 	say.Debug("Creating temporary test assets in " + temporaryDirectory)
-	err := os.MkdirAll(temporaryDirectory, 0755)
+	err := os.MkdirAll(temporaryDirectory, 0o755)
 	if err != nil {
 		say.Error("Could not create temporary dir " + temporaryDirectory)
 		say.Error(err.Error())
@@ -2138,7 +2189,7 @@ func createTestbedIn(t *testing.T, temporaryDirectory string) {
 	}
 
 	notGitDirectory := getNotGitDirectory(temporaryDirectory)
-	err = os.MkdirAll(notGitDirectory, 0755)
+	err = os.MkdirAll(notGitDirectory, 0o755)
 	if err != nil {
 		say.Error("Count not create directory " + notGitDirectory)
 		say.Error(err.Error())
@@ -2162,7 +2213,6 @@ func assertNoError(t *testing.T, err error) {
 	if err != nil {
 		failWithFailure(t, nil, err)
 	}
-
 }
 
 func assertError(t *testing.T, err error, errorMessage string) {
@@ -2223,7 +2273,7 @@ func createFile(t *testing.T, filename string, content string) (pathToFile strin
 func createFileInPath(t *testing.T, path, filename, content string) (pathToFile string) {
 	contentAsBytes := []byte(content)
 	pathToFile = path + "/" + filename
-	err := os.WriteFile(pathToFile, contentAsBytes, 0644)
+	err := os.WriteFile(pathToFile, contentAsBytes, 0o644)
 	if err != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
@@ -2235,7 +2285,7 @@ func createExecutableFileInPath(t *testing.T, path, filename, content string) (p
 
 	pathToFile = path + "/" + filename
 	contentAsBytes := []byte(content)
-	err := os.WriteFile(pathToFile, contentAsBytes, 0755)
+	err := os.WriteFile(pathToFile, contentAsBytes, 0o755)
 	if err != nil {
 		failWithFailure(t, "creating file "+filename+" with content "+content, "error")
 	}
@@ -2247,7 +2297,7 @@ func createDirectory(t *testing.T, directory string) (pathToDirectory string) {
 }
 
 func ensureDirectoryExists(t *testing.T, path string) (pathToDirectory string) {
-	err := os.MkdirAll(path, 0755)
+	err := os.MkdirAll(path, 0o755)
 	if err != nil {
 		failWithFailure(t, "creating folder "+path, "error")
 	}
@@ -2373,7 +2423,7 @@ func cleanRepository(path string) {
 func createRemoteRepository(path string) {
 	branch := "master" // fixed to master for now
 	say.Debug("createremoterepository: Creating remote repository " + path)
-	err := os.MkdirAll(path, 0755)
+	err := os.MkdirAll(path, 0o755)
 	if err != nil {
 		say.Error("Could not create directory " + path)
 		say.Error(err.Error())
@@ -2391,7 +2441,7 @@ func createRemoteRepository(path string) {
 
 func cloneRepository(path, remoteDirectory string) {
 	say.Debug("clonerepository: Cloning remote " + remoteDirectory + " to " + path)
-	err := os.MkdirAll(path, 0755)
+	err := os.MkdirAll(path, 0o755)
 	if err != nil {
 		say.Error("Could not create directory " + path)
 		say.Error(err.Error())


### PR DESCRIPTION
Users can configure MOB_SKIP_CI_PUSH_OPTION_ENABLED so the ci.skip push option is added when running mob start.

This pull request extends this configuration to include ci.skip when running mob next.