### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/virustotal.yaml
+++ b/.github/workflows/virustotal.yaml
@@ -8,10 +8,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
       -
@@ -23,7 +23,7 @@ jobs:
           GOOS=darwin GOARCH=arm64 go build -o ./mob-virustotal-macos-arm -v
       -
         name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v4
+        uses: crazy-max/ghaction-virustotal@v5
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           files: |


### PR DESCRIPTION
- actions/checkout: v4 → v6
- actions/setup-go: v5 → v6
- crazy-max/ghaction-virustotal: v4 → v5