### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
             git-version: 2.20.0
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Install old git version (macOS)
       if: ${{ matrix.os == 'macos-latest' && matrix.git-version != 'latest'}}
       run: |
@@ -34,7 +34,7 @@ jobs:
     - name: Show git version
       run: git version
     - name: Use Go 1.22.x
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.22'
     - name: Test


### PR DESCRIPTION
- actions/checkout: v4 → v6
- actions/setup-go: v5 → v6