### PR TITLE
Update GitHub Actions to Node.js 24 compatible versions in release an…

### DIFF
--- a/.github/workflows/publish-aur.yaml
+++ b/.github/workflows/publish-aur.yaml
@@ -11,7 +11,7 @@ jobs:
       VERSION: v5.2.0  # Set this to the tag name of the release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download checksum file
         run: |
@@ -50,13 +50,13 @@ jobs:
           EOF
 
       - name: Store PKGBUILD as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PKGBUILD
           path: ./aur/${{ env.PACKAGE_NAME }}/PKGBUILD
 
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: ${{ env.PACKAGE_NAME }}
           pkgver: ${{ env.PKGVER }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,9 @@ jobs:
     outputs:
       sha_linux: ${{ steps.shasum.outputs.sha_linux }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Go 1.22.x
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
       - name: Test
@@ -44,7 +44,7 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
       - name: VirusTotal Scan
-        uses: crazy-max/ghaction-virustotal@v3
+        uses: crazy-max/ghaction-virustotal@v5
         with:
           vt_api_key: ${{ secrets.VT_API_KEY }}
           update_release_body: true
@@ -125,12 +125,12 @@ jobs:
 
           EOF
       - name: Store PKGBUILD as an artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PKGBUILD
           path: ./aur/${{ env.PACKAGE_NAME }}/PKGBUILD
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v2.2.5
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: ${{ env.PACKAGE_NAME }}
           pkgbuild: ./aur/${{ env.PACKAGE_NAME }}/PKGBUILD


### PR DESCRIPTION
…d AUR workflows

release.yaml:
- actions/checkout: v4 → v6
- actions/setup-go: v5 → v6
- crazy-max/ghaction-virustotal: v3 → v5
- actions/upload-artifact: v4 → v7
- KSXGitHub/github-actions-deploy-aur: v2.2.5 → v4.1.3

publish-aur.yaml:
- actions/checkout: v4 → v6
- actions/upload-artifact: v4 → v7
- KSXGitHub/github-actions-deploy-aur: v2.2.5 → v4.1.3